### PR TITLE
Allow override of `DJANGO_DEBUG` variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@
     - sudo apt-get update
     - sudo apt-get install -y git python python-pip python-dev libffi-dev libssl-dev software-properties-common python-software-properties
     - sudo apt-get purge --auto-remove redis-server
-    - sudo pg_dropcluster --stop 9.1 main
     - sudo pg_dropcluster --stop 9.2 main
     - sudo pg_dropcluster --stop 9.3 main
     - sudo pg_dropcluster --stop 9.4 main

--- a/group_vars/atmosphere
+++ b/group_vars/atmosphere
@@ -95,7 +95,7 @@ ATMO:
         DATABASE_PASSWORD: "{{ atmosphere_database_password }}"
         DATABASE_PORT: 5432
         DATABASE_USER: "{{ atmosphere_database_user }}"
-        DJANGO_DEBUG: True
+        DJANGO_DEBUG: {{ DEBUG | default(True)}}
         ENFORCING: "{{ ENFORCING | default(False) }}"
         DJANGO_JENKINS: "{{ install_jenkins }}"
         SESSION_COOKIE_AGE:

--- a/group_vars/atmosphere
+++ b/group_vars/atmosphere
@@ -95,7 +95,7 @@ ATMO:
         DATABASE_PASSWORD: "{{ atmosphere_database_password }}"
         DATABASE_PORT: 5432
         DATABASE_USER: "{{ atmosphere_database_user }}"
-        DJANGO_DEBUG: {{ DEBUG | default(True)}}
+        DJANGO_DEBUG: "{{ DEBUG | default(True)}}"
         ENFORCING: "{{ ENFORCING | default(False) }}"
         DJANGO_JENKINS: "{{ install_jenkins }}"
         SESSION_COOKIE_AGE:


### PR DESCRIPTION
The [`DEBUG` and `SEND_EMAILS` variables](https://github.com/cyverse/atmosphere/blob/master/atmosphere/settings/local.py.j2#L14-L16) defined for `atmosphere/settings.local.py` are set based on the `DJANGO_DEBUG` variable. Unfortunately, this variables within Clank `group_vars/atmosphere` is not defined in a way that makes it easily overridden in a "build-environment" file (see commit 4f9343d for more discussion).

This pull request defined `DJANGO_DEBUG` within `[local.py]` based on the `DEBUG` variable in `group_vars/atmosphere` placed with "override" session:

```
# ....
###############################
#5. Overrides for Clank Execution
###############################
# Uncomment for faster Clank run (you will not get very latest packages, do not use in production!)
faster_dev_rebuild: true

DEBUG: False
```

<details>
I demonstrate the variable being set within a vagrant environment.

Based on the "local" vagrant environment:
```
 ./clank.py -e /vagrant/clank_init/build_env/variables.yml@local
```

Output:
```
PLAY RECAP *********************************************************************
localhost                  : ok=157  changed=90   unreachable=0    failed=0   

Wednesday 21 December 2016  17:43:37 +0000 (0:00:00.031)       0:17:54.138 **** 
=============================================================================== 
build-install-troposphere-ui-assets : run npm install ----------------- 216.81s
build-install-troposphere-ui-assets : run npm install after failed first attempt - 210.46s
app-pip-install-requirements : pip install requirements --------------- 170.58s
clone-repo : clone git repo with branched defined ---------------------- 80.65s
build-install-troposphere-ui-assets : run npm build -------------------- 79.85s
clone-repo : clone git repo with branched defined ---------------------- 60.39s
install-dependencies : add apt repositories ---------------------------- 45.76s
app-django-manage-migrate : django manage migrate ---------------------- 41.70s
setup-webserver-user-group : add webserver-user for user and group permissions -- 31.30s
install-dependencies : install dev packages ---------------------------- 20.80s
app-pip-install-requirements : pip install requirements ---------------- 18.11s
install-dependencies : update cache as a separate step ----------------- 11.43s
install-dependencies : update cache as a separate step ----------------- 10.84s
install-dependencies : install nginx packages --------------------------- 9.78s
app-alter-kernel-for-imaging : install dev packages --------------------- 7.19s
install-dependencies : install lib packages ----------------------------- 5.76s
build-install-troposphere-ui-assets : remove node modules after failed first attempt --- 5.02s
clone-repo : clone git repo with branched defined ----------------------- 3.47s
app-django-manage-load-tables : django manage load data fixture(s) ------ 3.28s
setup-virtualenv : Manually create the initial virtualenv --------------- 2.07s
Total Runtime: 0:17:54.859404
/opt/dev/clank/clank_env/bin/ansible-playbook "/opt/dev/clank/playbooks/deploy_stack.yml" --flush-cache -c local -e "@/vagrant/clank_init/build_env/variables.yml@local" -i /opt/dev/clank/hosts 
```

You can see that `SEND_EMAILS` is set as expected (when `DEBUG: False` is defined in `group_vars/atmosphere`):
```
(clank_env) root@vagrant-ubuntu-trusty-64:/opt/dev/clank# grep --context=4 "SEND_EMAILS" /opt/dev/atmosphere/atmosphere/settings/local.py
globals().update(vars(sys.modules['atmosphere.settings']))

# Debug Mode
DEBUG = False
SEND_EMAILS = True

template_backends = filter(lambda t:
    t['BACKEND'] == 'django.template.backends.django.DjangoTemplates',
    TEMPLATES)
```

The build environment file passed to `./clank.py`:
```
(clank_env) root@vagrant-ubuntu-trusty-64:/opt/dev/clank# grep --context=4 "DEBUG" /vagrant/clank_init/build_env/variables.yml@local 
###############################
# Uncomment for faster Clank run (you will not get very latest packages, do not use in production!)
faster_dev_rebuild: true

DEBUG: False
```
</details>

## Post merged 

- [ ] Update the appropriate build-environments to ensure `DEBUG: False` override in place

