### PR TITLE
Don't explicitly define database names in backup_db playbook which conflict with default database names elsewhere in Clank

### DIFF
--- a/playbooks/utils/backup_db.yml
+++ b/playbooks/utils/backup_db.yml
@@ -21,6 +21,5 @@
 
   roles:
     - { role: app-backup-postgres,
-        database_names: [ 'atmo_prod', 'troposphere'],
         tags: ['data-backup', 'backup', 'upgrade'] }
 


### PR DESCRIPTION
The backup_db playbook had hard-coded database names (`atmo-prod` and `troposphere`) that do not match the default database names that Clank creates if you do not specify database names (`atmosphere` and `troposphere`). This PR removes those hard-coded names, fixing an error condition that occurs when you try to run the backup_db playbook against an Atmosphere that was deployed with Clank's defaults. Instead, all databases should be backed up.