### PR TITLE
Problem: For development I always need full history, but Clank checks…

### DIFF
--- a/group_vars/common
+++ b/group_vars/common
@@ -17,3 +17,4 @@ maintenance_exempt_usernames: "{{ MAINTENANCE_EXEMPT_USERNAMES | default(staff_l
 install_jenkins: "{{ DJANGO_JENKINS | default(False) }}"
 installation_type: "{{ INSTALLATION_TYPE | default('development') }}"
 faster_dev_rebuild: false
+shallow_clone: true

--- a/roles/clone-repo/tasks/main.yml
+++ b/roles/clone-repo/tasks/main.yml
@@ -1,8 +1,18 @@
-- name: clone git repo with branched defined
+- name: clone git repo with branched defined (shallow)
   git:
     repo: "{{ REPO_URI }}"
     dest: "{{ CLONE_TARGET }}"
     clone: yes
-    depth: "{{ GIT_CLONE_DEPTH | default(1) }}"
+    depth: 1
     update: yes
     version: "{{ SPECIFIC_BRANCH | default('master', true) }}"
+  when: "{{ shallow_clone }}"
+
+- name: clone git repo with branched defined (deep)
+  git:
+    repo: "{{ REPO_URI }}"
+    dest: "{{ CLONE_TARGET }}"
+    clone: yes
+    update: yes
+    version: "{{ SPECIFIC_BRANCH | default('master', true) }}"
+  when: "{{ not shallow_clone }}"

--- a/roles/clone-repo/tasks/main.yml
+++ b/roles/clone-repo/tasks/main.yml
@@ -1,18 +1,8 @@
-- name: clone git repo with branched defined (shallow)
+- name: clone git repo with branched defined 
   git:
     repo: "{{ REPO_URI }}"
     dest: "{{ CLONE_TARGET }}"
     clone: yes
-    depth: 1
+    depth: "{%- if shallow_clone -%}1{%- else -%}0{%- endif -%}"
     update: yes
     version: "{{ SPECIFIC_BRANCH | default('master', true) }}"
-  when: "{{ shallow_clone }}"
-
-- name: clone git repo with branched defined (deep)
-  git:
-    repo: "{{ REPO_URI }}"
-    dest: "{{ CLONE_TARGET }}"
-    clone: yes
-    update: yes
-    version: "{{ SPECIFIC_BRANCH | default('master', true) }}"
-  when: "{{ not shallow_clone }}"

--- a/roles/clone-repo/tasks/main.yml
+++ b/roles/clone-repo/tasks/main.yml
@@ -3,6 +3,6 @@
     repo: "{{ REPO_URI }}"
     dest: "{{ CLONE_TARGET }}"
     clone: yes
-    depth: 1
+    depth: "{{ GIT_CLONE_DEPTH | default(1) }}"
     update: yes
     version: "{{ SPECIFIC_BRANCH | default('master', true) }}"


### PR DESCRIPTION
… out the

repositories to a depth of 1 by default. `git fetch --unshallow` gets tedious.

Solution: Add a setting you can add in your variables.yml@local to get all the
history:

```
GIT_CLONE_DEPTH: 0
```