### PR TITLE
Fix incorrect permissions for database user, allow connections on domain sockets

### DIFF
--- a/group_vars/atmosphere
+++ b/group_vars/atmosphere
@@ -86,7 +86,7 @@ ATMO:
         OAUTH_CLIENT_SECRET: "{{ ATMO_OAUTH_CLIENT_SECRET | default('') }}"
         DATABASE_CONN_MAX_AGE: "{{ conn_max_age }}"
         DATABASE_ENGINE: "{{ database_engine }}"
-        DATABASE_HOST: localhost
+        DATABASE_HOST: ""
         DATABASE_NAME: "{{ ATMO_DBNAME | default(atmosphere_database_name) }}"
         DATABASE_PASSWORD: "{{ atmosphere_database_password }}"
         DATABASE_PORT: 5432

--- a/group_vars/troposphere
+++ b/group_vars/troposphere
@@ -71,7 +71,7 @@ TROPO:
         DATABASE_USER: "{{ troposphere_database_user }}"
         DATABASE_CONN_MAX_AGE: "{{ conn_max_age }}"
         DATABASE_PASSWORD: "{{ troposphere_database_password }}"
-        DATABASE_HOST: localhost
+        DATABASE_HOST: ""
         DATABASE_PORT: 5432
         DJANGO_JENKINS: "{{ install_jenkins }}"
         SSLSERVER: True

--- a/roles/setup-postgres/tasks/main.yml
+++ b/roles/setup-postgres/tasks/main.yml
@@ -1,14 +1,29 @@
+# We must remove the line that we want to insert, otherwise ansible will not
+# respect "insertbefore". It's only respected when inserting lines that don't
+# already exist, so if you want to insert a line, you must remove it first.
+#
+# https://github.com/ansible/ansible/issues/21176#issuecomment-278557219
+#
+- block:
+    - name: "Explicitly remove database user, to ensure inserting in the right location"
+      lineinfile:
+          dest: "/etc/postgresql/{{ DB_VERSION }}/main/pg_hba.conf"
+          regexp: "^local +all +{{ DBUSER }} +md5"
+          state: absent
 
-- name: insert/update "Database User" configuation block in /etc/postgresql/{{ DB_VERSION }}/main/pg_hba.conf
-  blockinfile:
-    dest: "/etc/postgresql/{{ DB_VERSION }}/main/pg_hba.conf"
-    block: |
-      local   all              {{ item }}                  md5
-    marker: "# {mark} ANSIBLE MANAGED BLOCK {{item}}"
-  with_items:
-      - "{{ DBUSER }}"
-    
-- name: PostgreSQL - Ensure PostgreSQL is running
-  service: name=postgresql state=started args={{ DB_VERSION }}
+    - name: "Give database user ({{ DBUSER }}) password authentication on domain sockets"
+      lineinfile:
+        dest: "/etc/postgresql/{{ DB_VERSION }}/main/pg_hba.conf"
+
+        # Note: We must insert 'line' before this more restrictive line, if it exists.
+        insertbefore: "^local +all +all +peer"
+
+        line: "local   all              {{ DBUSER }}                  md5"
+
+  tags:
+    - postgres
+
+- name: Restart postgres to reload configuration
+  service: name=postgresql state=restarted args={{ DB_VERSION }}
   tags:
     - postgres


### PR DESCRIPTION
### Problem:
Our django apps don't talk to the database via unix sockets.

### Expanation:

This is what _used_ to be our `pg_hba.conf`.
```
local   all              all                       peer  
...                 
local   all              atmo_app                  md5
```

The issue is that the lower line (which we add) is overriden by the above line, because the above is more restrictive. It states:
>On domain sockets, for all databases and all users require auth via unix login credentials

This pr ensures the proper ordering. Because our apps could not login via unix auth, they resorted to tcp over the loopback interface. Now they use domain sockets.

This is significant, because engaging the network stack adds about 33%
overhead compared to domain sockets.
http://stackoverflow.com/a/12101626/1213041

Finally, in order for django with postgres to use domain sockets we need:
```
DATBASE_HOST=""
```
https://docs.djangoproject.com/en/1.10/ref/settings/#host

I tested this against a local vm and verified that traffic was no longer being sent over tcp to the database but thought a unix socket. I tested our existing `pg_hba.conf` files and that this ansible, correctly fixes the ordering.