### PR TITLE
Include atmosphere in the Linux Startup process (via rc.local)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@
     - cp dist_files/variables.yml.dist variables.yml
 
   script:
-    - clank_env/bin/python ./clank.py --env_file variables.yml -b --skip-tags "distro-update,create-nginx-uwsgi"
+    - clank_env/bin/python ./clank.py --env_file variables.yml -b --skip-tags "distro-update,create-nginx-uwsgi,enable-services"

--- a/playbooks/deploy_stack.yml
+++ b/playbooks/deploy_stack.yml
@@ -10,3 +10,4 @@
 - include: ./prepare_host.yml
 - include: ./deploy_atmosphere.yml
 - include: ./deploy_troposphere.yml
+- include: ./post_deployment.yml

--- a/playbooks/post_deployment.yml
+++ b/playbooks/post_deployment.yml
@@ -1,0 +1,8 @@
+---
+- name: Post deployment of atmosphere/troposphere
+  hosts: all
+  roles:
+    - { role: atmosphere-include-startup,
+        tags: ['post-install','atmosphere'] }
+  tags:
+    - post-install

--- a/roles/app-alter-kernel-for-imaging/tasks/main.yml
+++ b/roles/app-alter-kernel-for-imaging/tasks/main.yml
@@ -23,5 +23,9 @@
   lineinfile: dest=/etc/rc.local insertbefore=EOF line="exit 0"
 
 - name: add modprobe nbd for imaging to /etc/rc.local for subsequent reboots
-  lineinfile: dest=/etc/rc.local insertbefore="exit 0" line="modprobe {{ item.name }} {{ item.params | default(omit) }}"
+  lineinfile:
+    dest: /etc/rc.local
+    insertbefore: "exit 0"
+    line: "modprobe {{ item.name }} {{ item.params | default(omit) }}"
+    regexp: "modprobe {{ item.name }}"
   with_items: MODPROBE_PACKAGES.packages

--- a/roles/atmosphere-include-startup/README.md
+++ b/roles/atmosphere-include-startup/README.md
@@ -1,0 +1,38 @@
+atmosphere-include-startup
+=========
+
+This role will ensure that atmosphere is setup to 'auto-start' whenever the server is booted.
+This role is intended to be executed as part of the 'deploy_stack' playbook in clank in the 'post_deployment' section.
+
+
+Requirements
+------------
+
+N/A
+
+Role Variables
+--------------
+
+N/A
+
+Dependencies
+------------
+
+N/A
+
+Example Playbook
+----------------
+
+    - hosts: all
+      roles:
+         - atmosphere-include-startup
+
+License
+-------
+
+See license.md
+
+Author Information
+------------------
+Steve Gregory
+https://cyverse.org

--- a/roles/atmosphere-include-startup/license.md
+++ b/roles/atmosphere-include-startup/license.md
@@ -1,0 +1,37 @@
+Copyright (c) 2011, The Arizona Board of Regents on behalf of
+The University of Arizona
+
+All rights reserved.
+
+Developed by: iPlant Collaborative as a collaboration between
+participants at BIO5 at The University of Arizona (the primary hosting
+institution), Cold Spring Harbor Laboratory, The University of Texas at
+Austin, and individual contributors. Find out more at
+http://www.iplantcollaborative.org/.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of the iPlant Collaborative, BIO5, The University
+   of Arizona, Cold Spring Harbor Laboratory, The University of Texas at
+   Austin, nor the names of other contributors may be used to endorse or
+   promote products derived from this software without specific prior
+   written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/roles/atmosphere-include-startup/tasks/main.yml
+++ b/roles/atmosphere-include-startup/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+# tasks file for atmosphere-include-startup
+- name: Include atmosphere in the startup process
+  service:
+    name: 'atmosphere'
+    enabled: 'yes'

--- a/roles/atmosphere-include-startup/tasks/main.yml
+++ b/roles/atmosphere-include-startup/tasks/main.yml
@@ -4,3 +4,4 @@
   service:
     name: 'atmosphere'
     enabled: 'yes'
+  tags: enable-services


### PR DESCRIPTION
Summary:
- Include a new playbook to handle post_deployment steps
- include a new post deployment step: add atmosphere to startup (via rc.local)

Tests:
- [x] Verify that the two rc.local lines (modprobe, service atmosphere start) don't thrash the file. 
- [x] Verify that only one copy of each line should exist in the file.
