### PR TITLE
Problem: add theme-specific variable population

### DIFF
--- a/group_vars/troposphere
+++ b/group_vars/troposphere
@@ -22,14 +22,23 @@ TROPO_LOG_FILES:
 TROPO:
     COMMON:
         ASSETS_PATH: "{{ TROPOSPHERE_LOCATION | default(troposphere_directory_path) }}/troposphere/assets"
-        THEME_PATH: "{{ TROPOSPHERE_LOCATION | default(troposphere_directory_path) }}/troposphere/themes"
-        THEME_NAME: "{{ troposphere_theme_name }}"
         DJANGO_SERVER_URL: "{{ troposphere_server_url }}"
         SERVER_URL: "{{ troposphere_server_url }}"
         LDAP_SERVER: "{{ LDAP_SERVER | default('') }}"
         LDAP_SERVER_DN: "{{ LDAP_SERVER_DN | default('') }}"
         TOKEN_EXPIRY_TIME_DAYS: 1
-
+    theme:
+        USE_THEME_IMAGES: "{{ THEME_IMAGES_PATH is defined }}"
+        PRIMARY_ONE_COLOR: "{{ PRIMARY_ONE_COLOR | default('')}}" 
+        PRIMARY_TWO_COLOR: "{{ PRIMARY_TWO_COLOR | default('')}}" 
+        ACCENT_ONE_COLOR: "{{ ACCENT_ONE_COLOR | default('') }}"
+        PICKER_HEADER_COLOR: "{{ PICKER_HEADER_COLOR | default('') }}"
+        DANGER_COLOR: "{{ DANGER_COLOR | default('') }}"
+        SUCCESS_COLOR: "{{ SUCCESS_COLOR | default('') }}"
+        HEADER_COLOR: "{{ HEADER_COLOR | default('') }}"
+        HEADER_BORDER_COLOR: "{{ HEADER_BORDER_COLOR | default('') }}"
+        HEADER_LINK_COLOR: "{{ HEADER_LINK_COLOR | default('') }}"
+        LINK_COLOR: "{{ LINK_COLOR | default('') }}"
     nginx:
         ENABLE_HTTP2: True
         TROPOSPHERE_PATH: "{{ TROPOSPHERE_LOCATION | default(troposphere_directory_path) }}"

--- a/playbooks/setup_troposphere.yml
+++ b/playbooks/setup_troposphere.yml
@@ -69,6 +69,9 @@
         UWSGI_INI_SRC_NAME: 'extras/troposphere.uwsgi.ini',
         tags: ['troposphere', 'create-nginx-uwsgi'] }
 
+    - { role: install-theme,
+        tags: ['troposphere', 'theme'] }
+
     - { role: build-install-troposphere-ui-assets,
         NPM_APP_DIR: "{{ TROPOSPHERE_LOCATION | default(troposphere_directory_path) }}",
         NPM_BUILD_TYPE: "{{ TROPOSPHERE_BUILD | default('production') }}",

--- a/roles/install-theme/tasks/main.yml
+++ b/roles/install-theme/tasks/main.yml
@@ -1,0 +1,7 @@
+- file:
+    src: "{{ THEME_IMAGES_PATH }}"
+    dest: /opt/dev/troposphere/troposphere/static/theme/themeImages
+    owner: www-data
+    group: www-data
+    state: link
+  when: "{{ THEME_IMAGES_PATH is defined }}"


### PR DESCRIPTION
# Adding Theme Vars and Role, [ATMO-1734](https://pods.iplantcollaborative.org/jira/browse/ATMO-1734)
_This is failing travis because it is dependent on [PR 560](https://github.com/cyverse/troposphere/pull/560). Test locally with [this branch](https://github.com/Tharon-C/troposphere/tree/ATMO-1734-cy-ui-integration)_

This PR is part of ATMO-1734 integrating CY-UI and MUI into troposphere. These libraries use a configuration object for theming over the current CSS method. Now theme colors are set as vars and a custom images folder can be provided to change the logos, CTA images, and favicon. 

### Changes
- Add theme group vars
- Create role for symlinking images folder into troposphere theme. 
- Add role to tropo playbook and use theme tag

### Steps to finish
- [x] Reviewed by peer
- [ ] Add documentation and commented out vars to environment repos