### PR TITLE
Problem: Theme documentation is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,32 @@ Any arguments that Clank itself doesn't recognize will be passed to the resultin
 The location of these files *must* be stated in your _completed_
 [variables.yml](https://github.com/CyVerse/clank/blob/master/dist_files/variables.yml.dist#L52-L63).  # FIXME: bad linked-lines.
 
+## Custom Theme
+
+You can change the images and colors used in [troposphere](https://github.com/cyverse/troposphere) to reflect your own institution's  branding.
+
+### Theme Images
+To change images like the logo or favicon, add the absolute path to your theme images folder to the variable `THEME_IMAGES_PATH` in `variables.yml`.
+```
+THEME_MAGES_PATH: "/absoulte/path/to/your-images"
+```
+We recomened copying the `defaultThemeImages` folder found in Troposphere
+`<projectRoot>/troposphere/static/theme/themeImagesDefault`
+
+Replace any image in the folder with your new image keeping the same name and file type. It is important that the new image has the same dimensions and uses a transparent background or it may not display correctly. Your image may not be the same ratio as the image you are replacing but the file should be. For example, your logo might be shorter in length given the same height. Without distorting the logo ratio, align it to the left of the file and export the file at the same dimensions of the original file.
+ 
+
+```
+File Dimentions
++++++++++++++++++++++++++++
++--------------------     +
++| Logo Dimentions  |     +
++--------------------     +
++++++++++++++++++++++++++++
+```
+### Theme Colors
+To change the theme colors edit the color variable. Colors are used by cyverse-ui and Material-ui for components like buttons, toggles, radios, etc... See [Our Style Guide](https://cyverse.github.io/cyverse-ui/) for more information on how colors are used by components.
+
 ## Contributing to clank
 
 Generally, new roles should be created using [ansible-role-template](https://github.com/cyverse-ansible/ansible-role-template), using Ansible Galaxy and Travis CI as detailed [here](https://pods.iplantcollaborative.org/wiki/display/csmgmt/Ansible+at+CyVerse#AnsibleatCyVerse-AnsibleGalaxyRoles) (only visible to CyVerse staff).

--- a/dist_files/variables.yml.dist
+++ b/dist_files/variables.yml.dist
@@ -149,12 +149,14 @@ AUTH_MOCK_USER: "atmosphere_user"
 
 ###
 # 3c: Theme configuration
+# Set custom colors and images for your instance of Troposphere leaving undefined will default to the Cyverse Troposphere theme.
 ###
 
 ###
 # THEME_IMAGES_PATH, expects an absolute path to an images directory
-# Find the included theme-images directory
-# Replace any image with a new image of equal size and name
+# We recommend making a copy of the themeImagesDefault directory in Troposphere 
+# <projectDir>/troposphere/static/theme/themeImagesDefault
+# Place it in an init directory and replace any image with a new image of equal size and name
 # Uncomment the variable below.
 ###
 

--- a/dist_files/variables.yml.dist
+++ b/dist_files/variables.yml.dist
@@ -147,6 +147,36 @@ AUTH_MOCK_USER: "atmosphere_user"
 # SUPPORT_EMAIL_SIGNATURE: Support Team
 # SUPPORT_LINKS: {'getting_started': "https://google.com/",'new_provider': "https://google.com"}
 
+###
+# 3c: Theme configuration
+###
+
+###
+# THEME_IMAGES_PATH, expects an absolute path to an images directory
+# Find the included theme-images directory
+# Replace any image with a new image of equal size and name
+# Uncomment the variable below.
+###
+
+#THEME_IMAGES_PATH: ""
+
+###
+# The Theme Colors below, expect hex color strings
+# Change the look of Troposphere by defining your own colors
+# Visit https://cyverse.github.io/cyverse-ui/ for more information on how these colors are used
+###
+
+#PRIMARY_ONE_COLOR: "#ed174b"
+#PRIMARY_TWO_COLOR: "#46afc8"
+#HEADER_BORDER_COLOR: "#ed174b"
+#HEADER_LINK_COLOR: "black"
+#PICKER_HEADER_COLOR: "#46afc8"
+#HEADER_COLOR: "white"
+#LINK_COLOR: "#46afc8"
+#ACCENT_ONE_COLOR: "#46afc8"
+#SUCCESS_COLOR: ""
+#DANGER_COLOR: ""
+
 ###############################
 #4. Optional Plugins
 #   These features are NOT required to run Atmosphere+Troposphere


### PR DESCRIPTION
This adds theme documentation in variables.yml.dist

Includes what the variables are, how to use them, and uses Jetstream colors as commented out example. 