### PR TITLE
Problem: Missing defaults for allocation group vars

### DIFF
--- a/group_vars/troposphere
+++ b/group_vars/troposphere
@@ -137,6 +137,9 @@ TROPO:
         INTERCOM_COMPANY_NAME: "{{ INTERCOM_COMPANY_NAME | default('') }}"
 
         USE_ALLOCATION_SOURCES: "{{ USE_ALLOCATION_SOURCE | default(False) }}"
+        EXTERNAL_ALLOCATION: "{{ EXTERNAL_ALLOCATION | default(True) }}"
+        ALLOCATION_UNIT_NAME: "{{ ALLOCATION_UNIT_NAME | default('Atmosphere Units') }}"
+        ALLOCATION_UNIT_ABBREV: "{{ ALLOCATION_UNIT_ABBREV | default('AU') }}"
         USE_MOCK_DATA: "{{ USE_MOCK_DATA | default(False) }}"
         USE_GATE_ONE_API: "{{ USE_GATE_ONE_API | default(False) }}"
         GATE_ONE_API_KEY: "{{ GATE_ONE_API_KEY | default('') }}"


### PR DESCRIPTION
Solution: Added defaults for:
- EXTERNAL_ALLOCATION
- ALLOCATION_UNIT_NAME
- ALLOCATION_UNIT_ABBREV

This PR is dependent on: https://github.com/cyverse/atmosphere/pull/340

This change is due to: https://github.com/cyverse/troposphere/pull/565/commits/0e12b6d37687a89cdadc561e7289cb4d5a2a5a18