### PR TITLE
Pull in latest ansible galaxy tls-cert role

### DIFF
--- a/roles/tls-cert/README.md
+++ b/roles/tls-cert/README.md
@@ -1,8 +1,8 @@
 TLS Certificate
 =========
 
-Does one of two things depending on configuration:
-- Installs your TLS certificate, private key, and CA certificate bundle to target system.
+Installs TLS (SSL) certificates to the target, in one of two ways depending on configuration:
+- Installs your provided TLS certificate, private key, and CA certificate bundle to target system.
 - Deploys a new self-signed certificate + key to target system.
 
 In either case, automatically creates a "full chain" file (containing certificate + CA bundle, suitable for use with Nginx) as well.

--- a/roles/tls-cert/meta/.galaxy_install_info
+++ b/roles/tls-cert/meta/.galaxy_install_info
@@ -1,1 +1,1 @@
-{install_date: 'Fri Jan 13 22:55:04 2017', version: master}
+{install_date: 'Tue May 16 23:56:24 2017', version: master}

--- a/roles/tls-cert/tasks/deploy-provided.yml
+++ b/roles/tls-cert/tasks/deploy-provided.yml
@@ -16,10 +16,34 @@
     - src_path: "{{ TLS_CACHAIN_SRC_FILE }}"
       dest_path: "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt"
 
+# These series of tasks deserve an explanation.
+#
+# In the task: 'Full certificate chain created', we must concatenate several
+# files. However we should only concatenate the files when any of the input
+# files have changed. At this time, ansible does not have a mechanism for
+# this. Here we manually check the timestamps of the dependencies and the
+# output and if the dependencies are newer, then we recreate the output file.
+# a la make.
+
+- command: stat -c "%Y" "{{ TLS_PRIVKEY_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.key"
+  register: key_timestamp
+  changed_when: False
+- command: stat -c "%Y"  "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt"
+  register: crt_timestamp
+  changed_when: False
+- command: stat -c "%Y"  "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt"
+  register: cachain_timestamp
+  changed_when: False
+- command: stat -c "%Y"  "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt"
+  register: fullchain_timestamp
+  ignore_errors: yes # Intentionally fail, if the file doesn't exist
+  changed_when: False
+
 - name: Full certificate chain created
   shell: >
     cat {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt
     {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt >>
     {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt
-  args:
-    creates: "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt"
+  when: fullchain_timestamp|failed or (key_timestamp.stdout|int()     > fullchain_timestamp.stdout|int())
+                                   or (crt_timestamp.stdout|int()     > fullchain_timestamp.stdout|int())
+                                   or (cachain_timestamp.stdout|int() > fullchain_timestamp.stdout|int())


### PR DESCRIPTION
The latest fixes the tls cert mismatch:
CyVerse-Ansible/ansible-tls-cert @d455f35:

> Create a new full chain cert when parts of the chain change
>
> Problem:
> When users were re-running clank, they were experiencing certificate mismatch
> errors, because our ansible was not recreating the full chain. It wasn't
> recreating it because the module performing the concatenation only
> checked if the full chain file previously existed not whether it should be
> recreated.
>
> Solution:
> Take a stroke from make, when ever the timestamps of the inputs are newer than
>     the output, regenerate the output.
>