### PR TITLE
Add support for running util playbooks via --playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ Supported tags: `dependencies`, `atmosphere`, `troposphere`
 You can actually specify any tag you may find in the roles and playbooks. Clank
 is a thin-wrapper over ansible.
 
+### Running Clank Utilities
+
+Clank comes with several useful [utilities](playbooks/utils/README.md) located
+in `./playbooks/utils/*`.
+
+To run a particular utility use the `--playbook` flag:
+```bash
+./clank.py -env_file $VARIABLES_YML_FILE --playbook playbooks/utils/upgrade_postgres.yml
+```
+
 ### Passing extra arguments to ansible-playbook
 
 Any arguments that Clank itself doesn't recognize will be passed to the resulting `ansible-playbook` run, which exposes the full capabilities of the `ansible-playbook` command. For example, if you have secrets that are encrypted with Ansible Vault, you can append `--ask-vault-pass` to your Clank command, and Ansible will prompt you for a password interactively.

--- a/clank.py
+++ b/clank.py
@@ -42,17 +42,9 @@ def setup_arguments():
         action='store_true',
         help="toggle on verbose output for command and shell tasks")
 
-    parser.add_argument("--run-virtualenv",
-        action='store_true',
-        help="Run 'create_release_virtualenvs' utility-playbook, rather than execute deployment playbook")
-
-    parser.add_argument("--run-upgrade-postgres",
-        action='store_true',
-        help="Run 'upgrade_postgres' utility-playbook, rather than execute deployment playbook")
-
-    parser.add_argument("--run-backup",
-        action='store_true',
-        help="Run 'perform_backup' utility-playbook, rather than execute deployment playbook")
+    parser.add_argument("--playbook",
+        type=str,
+        help="Run a specific playbook, rather than the default deployment playbook")
 
     parser.add_argument("--debug",
         action='store_true',
@@ -99,13 +91,8 @@ def execute_ansible_playbook(args, extra_ansible_playbook_args):
         options += ' -vvvvv -e"CLANK_VERBOSE=true"'
     if args.debug:
         options += ' --tags print-vars'
-    #FIXME: Before adding another 'ansible_play =' line, convert this call to `--run-utility X`
-    if args.run_backup:
-        ansible_play = '{}/playbooks/utils/perform_backup.yml'.format(cur_dir)
-    if args.run_virtualenv:
-        ansible_play = '{}/playbooks/utils/create_release_virtualenvs.yml'.format(cur_dir)
-    if args.run_upgrade_postgres:
-        ansible_play = '{}/playbooks/utils/upgrade_postgres.yml'.format(cur_dir)
+    if args.playbook:
+        ansible_play = args.playbook
     if args.extra:
         for extra_arg in args.extra:
             options += ' -e"%s"' % extra_arg

--- a/playbooks/utils/README.md
+++ b/playbooks/utils/README.md
@@ -7,9 +7,8 @@
 > Note: playbook assumes _"controller"_ is the **target** (see arguments below `... -c local -i "localhost,"`)
 
 ```
-ansible-playbook playbooks/utils/upgrade_postgres.yml \
-  --flush-cache -c local -i "localhost," \
-    -e "{pg_version: '9.5',  pg_version_old: '9.3', database_names: ['atmosphere', 'troposphere']}"
+./clank.py --playbook playbooks/utils/upgrade_postgres.yml \
+    --extra "{pg_version: '9.5',  pg_version_old: '9.3', database_names: ['atmosphere', 'troposphere']}"
 ```
 
 
@@ -23,7 +22,7 @@ This is a utility playbook to be install an optional component to enhance functi
 - `hosts` including `[novnc_proxy]` group
 
 ```
-ansible-playbook playbooks/utils/install_novnc_auth.yml \
+./clank.py --playbook playbooks/utils/install_novnc_auth.yml \
   -i hosts -e @/vagrant/clank_init/build_env/variables.yml
 ```
 


### PR DESCRIPTION
Problem: clank.py hardcodes utilities into the command options
Solution: allow a playbook to be passed to clank

I have a utility in the works which creates a certificate/ca and I wanted the experience to be better when adding support for another utility.