### PR TITLE
Add utility to self issue certs for local dev

### DIFF
--- a/playbooks/utils/README.md
+++ b/playbooks/utils/README.md
@@ -16,6 +16,17 @@
 
 This is a utility playbook to be install an optional component to enhance functionality of Atmosphere. The component is a transparent authentication proxy using Nginx to allow community members access to [noVNC](https://kanaka.github.io/noVNC/) running on an instance within the Atmosphere Cloud. 
 
+## create_ca_and_cert.yml
+
+This is a utility playbook to create a certificate authority (CA) and
+certificates signed by said authority. See this companion
+[README](create_ca_and_cert_README.md) for a thorough
+walkthrough and explanation.
+
+```bash
+clank.py --playbook playbooks/utils/create_ca_and_cert.yml -e /path/to/variables.yml
+```
+
 ### Requirements
 
 - a valid "build_env" variables.yml for Atmosphere (described in Clank [README.md](https://github.com/CyVerse/clank#list-of-files-needed-before-hand); examples in [dist_files](https://github.com/CyVerse/clank/blob/master/dist_files/variables.yml.dist))

--- a/playbooks/utils/create_ca_and_cert.yml
+++ b/playbooks/utils/create_ca_and_cert.yml
@@ -1,0 +1,12 @@
+---
+- hosts: all
+  vars:
+       TLS_CA_CERT_DEST: "./{{ SERVER_NAME }}.ca.cert.pem"
+       TLS_CA_KEY_DEST: "./{{ SERVER_NAME }}.ca.key.pem"
+       TLS_CERT_REQUEST_DEST: "./{{ SERVER_NAME }}.server.csr.pem"
+       TLS_CERT_PRIVATE_KEY_DEST: "./{{ SERVER_NAME }}.server.key.pem"
+       TLS_SIGNED_CERT_DEST: "./{{ SERVER_NAME }}.server.cert.pem"
+  roles:
+   - { role: tls-create-ca, DOMAIN_NAME: "{{ SERVER_NAME }} CA" }
+   - { role: tls-create-csr, DOMAIN_NAME: "{{ SERVER_NAME }}" }
+   - tls-ca-sign-csr

--- a/playbooks/utils/create_ca_and_cert_README.md
+++ b/playbooks/utils/create_ca_and_cert_README.md
@@ -1,0 +1,92 @@
+# create_ca_and_cert.yml
+This is a utility playbook to create a certificate authority (CA) and
+certificates signed by said authority.
+See the background section below for an overview.
+
+Steps to perform:
+1. Create a CA and signed guest cert
+2. Install guest cert and key on guest machine
+3. Install CA cert on host machine
+4. Delete all traces of your CA private key **(DO NOT SKIP!)**
+
+## Create a CA and signed guest cert
+
+```bash
+clank.py --playbook playbooks/utils/create_ca_and_cert.yml -e /path/to/variables.yml
+```
+After running that playbook you should see a bunch of new `*.pem` files.
+
+## Install guest cert and key on guest machine
+
+Add/update the following variables in your variables file:
+```yaml
+TLS_PRIVKEY_SRC_FILE: "/path/to/*.server.key.pem"
+TLS_CERT_SRC_FILE:    "/path/to/*.server.cert.pem"
+TLS_CACHAIN_SRC_FILE: "/path/to/*.ca.cert.pem"
+```
+
+At this point you should do a redeploy.
+
+If you want to quickly verify the certs were installed run:
+```bash
+# Check that private key and cert indeed match
+nginx -t
+```
+
+## Install CA cert on host machine
+
+### Firefox
+If you're on Firefox you need to upload your certificate authority cert
+(`/path/to/*.ca.cert.pem`) into Firefox and restart Firefox.
+
+As of now you can navigate to preferences/advanced/certificates. You can then
+select "View Certificates" and then you can navigate to "Authorities" then
+click "import" and upload your certificate authority cert.
+
+Restart Firefox.
+
+### Chrome
+On OSX, Chrome looks up your certificates using OSX Keychain Acess. You will need to
+add it your keychain, manually trust it, then restart Chrome.
+
+Prompt dialog to import your CA
+```bash
+open /path/to/*.ca.cert.pem
+```
+
+This should add your CA to your system keychain. Now you must double click it
+in Keychain Access to manually trust it.
+
+Click the 'trust' dropdown then set "When using this certificate: Always Trust".
+When you close the window, it will prompt for your system credentials, then you
+should see the certificate icon momentarily change from being red to a light
+blue.
+
+Restart Chrome.
+
+
+## Delete your CA private key
+
+If anyone gets a hold of your certificate authority private key, they can
+impersonate any site and your browser will accept that fake site. I highly
+suggest that you delete this private key. You won't be able to issue further
+certificates but that is okay for your development environment, you can always
+create a new CA.
+
+Delete your Certificate Authority key:
+```bash
+rm /path/to/*.ca.key.pem
+
+```
+
+## Background for this approach
+When you visit a site, that site first sends the browser a certificate (stamp
+of approval) to prove its legitimacy.
+
+Your browser looks at the certificate and looks at who issued/signed the
+certificate. If the browser trusts the issuer, then it trusts the original
+site.
+
+One approach to setting up HTTPS for a development site is to become your own
+issuer (i.e Certificate Authority), sign the certificates that your
+development site will use, and lastly trust that issuer in your browser.

--- a/roles/tls-ca-sign-csr/README.md
+++ b/roles/tls-ca-sign-csr/README.md
@@ -1,0 +1,32 @@
+tls-ca-sign-csr
+=========
+
+Sign a certificate signing request with a certificate authority
+
+The intention is that this playbook will **not** be used in production. It is
+useful for local development but is otherwise a major liability.
+
+Role Variables
+--------------
+
+It accepts a CA certificate, ca key, and certificate request, and signs the request as the
+CA. It generates TLS_SIGNED_CERT_DEST. See example playbook below.
+
+| Variable                     | Required        | Default             | Choices | Comment                       |
+|------------------------------|-----------------|---------------------|---------|-------------------------------|
+| TLS_CA_CERT_DEST             | yes             |                     |         | Path to ca cert               |
+| TLS_CA_KEY_DEST              | yes             |                     |         | Path to ca key                |
+| TLS_CERT_REQUEST_DEST        | yes             |                     |         | Path to cert signing request  |
+| TLS_SIGNED_CERT_DEST         | no              | server_cert.pem     |         | Path to generated signed cert |
+
+Example Playbook
+----------------
+
+    - hosts: localhost
+      roles:
+       - { role: tls-ca-sign-csr,
+           TLS_CA_CERT_DEST: ./ca_cert.pem,
+           TLS_CA_KEY_DEST: ./ca_cert_key.pem,
+           TLS_CERT_REQUEST_DEST: ./server_cert_csr.pem }
+
+https://cyverse.org

--- a/roles/tls-ca-sign-csr/defaults/main.yml
+++ b/roles/tls-ca-sign-csr/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+TLS_SIGNED_CERT_DEST: server_cert.pem

--- a/roles/tls-ca-sign-csr/tasks/main.yml
+++ b/roles/tls-ca-sign-csr/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+- name: Create a directory to store temporary files
+  file:
+    path: "{{ role_path }}/build"
+    state: directory
+
+- template:
+    src: "{{ role_path }}/templates/openssl-ca.cnf.j2"
+    dest: "{{ role_path }}/build/openssl-ca.cnf"
+
+- name: Create empty initial CA index
+  copy:
+    content: ""
+    dest: "{{ role_path }}/build/index.txt"
+    force: yes
+
+- name: Create CA serial file
+  copy:
+    content: "01"
+    dest: "{{ role_path }}/build/serial.txt"
+    force: no
+
+- name: Produce a signed certificate
+  command: >
+    openssl ca
+      -config "{{ role_path }}/build/openssl-ca.cnf"
+      -outdir "{{ role_path }}/build"
+      -policy signing_policy
+      -extensions signing_req
+      -days 1000
+      -md sha256
+      -name CA_default
+      -noemailDN
+      -batch
+      -cert {{ TLS_CA_CERT_DEST }}
+      -keyfile {{ TLS_CA_KEY_DEST }}
+      -out {{ TLS_SIGNED_CERT_DEST }}
+      -infiles {{ TLS_CERT_REQUEST_DEST }}

--- a/roles/tls-ca-sign-csr/templates/openssl-ca.cnf.j2
+++ b/roles/tls-ca-sign-csr/templates/openssl-ca.cnf.j2
@@ -1,0 +1,22 @@
+RANDFILE        = $ENV::HOME/.rnd
+
+[ CA_default ]
+database        = {{ role_path }}/build/index.txt   # Database index file
+serial          = {{ role_path }}/build/serial.txt  # The current serial number
+copy_extensions = copy          # Required to copy SANs from CSR to cert
+unique_subject  = no
+
+[ signing_req ]
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+
+[ signing_policy ]
+countryName            = optional
+stateOrProvinceName    = optional
+localityName           = optional
+organizationName       = optional
+organizationalUnitName = optional
+commonName             = supplied
+emailAddress           = optional

--- a/roles/tls-cert/README.md
+++ b/roles/tls-cert/README.md
@@ -1,8 +1,8 @@
 TLS Certificate
 =========
 
-Installs TLS (SSL) certificates to the target, in one of two ways depending on configuration:
-- Installs your provided TLS certificate, private key, and CA certificate bundle to target system.
+Does one of two things depending on configuration:
+- Installs your TLS certificate, private key, and CA certificate bundle to target system.
 - Deploys a new self-signed certificate + key to target system.
 
 In either case, automatically creates a "full chain" file (containing certificate + CA bundle, suitable for use with Nginx) as well.

--- a/roles/tls-cert/meta/.galaxy_install_info
+++ b/roles/tls-cert/meta/.galaxy_install_info
@@ -1,1 +1,1 @@
-{install_date: 'Tue May 16 23:56:24 2017', version: master}
+{install_date: 'Fri Jan 13 22:55:04 2017', version: master}

--- a/roles/tls-cert/tasks/deploy-provided.yml
+++ b/roles/tls-cert/tasks/deploy-provided.yml
@@ -16,34 +16,10 @@
     - src_path: "{{ TLS_CACHAIN_SRC_FILE }}"
       dest_path: "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt"
 
-# These series of tasks deserve an explanation.
-#
-# In the task: 'Full certificate chain created', we must concatenate several
-# files. However we should only concatenate the files when any of the input
-# files have changed. At this time, ansible does not have a mechanism for
-# this. Here we manually check the timestamps of the dependencies and the
-# output and if the dependencies are newer, then we recreate the output file.
-# a la make.
-
-- command: stat -c "%Y" "{{ TLS_PRIVKEY_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.key"
-  register: key_timestamp
-  changed_when: False
-- command: stat -c "%Y"  "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt"
-  register: crt_timestamp
-  changed_when: False
-- command: stat -c "%Y"  "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt"
-  register: cachain_timestamp
-  changed_when: False
-- command: stat -c "%Y"  "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt"
-  register: fullchain_timestamp
-  ignore_errors: yes # Intentionally fail, if the file doesn't exist
-  changed_when: False
-
 - name: Full certificate chain created
   shell: >
     cat {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt
     {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt >>
     {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt
-  when: fullchain_timestamp|failed or (key_timestamp.stdout|int()     > fullchain_timestamp.stdout|int())
-                                   or (crt_timestamp.stdout|int()     > fullchain_timestamp.stdout|int())
-                                   or (cachain_timestamp.stdout|int() > fullchain_timestamp.stdout|int())
+  args:
+    creates: "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt"

--- a/roles/tls-cert/tasks/deploy-provided.yml
+++ b/roles/tls-cert/tasks/deploy-provided.yml
@@ -19,7 +19,5 @@
 - name: Full certificate chain created
   shell: >
     cat {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt
-    {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt >>
+    {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt >
     {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt
-  args:
-    creates: "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt"

--- a/roles/tls-create-ca/README.md
+++ b/roles/tls-create-ca/README.md
@@ -1,0 +1,35 @@
+tls-create-ca
+=========
+
+Create a certificate authority
+
+The intention is that this playbook will **not** be used in production. It is
+useful for local development but is otherwise a major liability.
+
+Role Variables
+--------------
+
+Without any configuration the role will spit out: `ca_cert.pem` and
+`ca_cert_key.pem` which are respectively the root cert and its private key.
+
+
+| Variable               | Required  | Default               | Choices | Comment |
+|------------------------|-----------|-----------------------|---------|---------|
+| TLS_CA_CERT_DEST       | no        | ca_cert.pem           |         |         |
+| TLS_CA_KEY_DEST        | no        | ca_cert_key.pem       |         |         |
+| COUNTRY_NAME           | no        | US                    |         |         |
+| STATE_OR_PROVINCE_NAME | no        | Arizona               |         |         |
+| LOCALITY_NAME          | no        | Tucson                |         |         |
+| ORGANIZATION_NAME      | no        | Organisation Name     |         |         |
+| ORG_UNIT_NAME          | no        | Organisation Division |         |         |
+| COMMON_NAME            | no        | Common Name CA        |         |         |
+| EMAIL_ADDRESS          | no        | test@example.com      |         |         |
+
+Example Playbook
+----------------
+
+    - hosts: localhost
+      roles:
+       - tls-create-ca
+
+https://cyverse.org

--- a/roles/tls-create-ca/defaults/main.yml
+++ b/roles/tls-create-ca/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+TLS_CA_CERT_DEST: ca_cert.pem
+TLS_CA_KEY_DEST: ca_cert_key.pem

--- a/roles/tls-create-ca/tasks/main.yml
+++ b/roles/tls-create-ca/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: Create a directory to store temporary files
+  file:
+    path: "{{ role_path }}/build"
+    state: directory
+
+- template:
+    src: "{{ role_path }}/templates/openssl-ca.cnf.j2"
+    dest: "{{ role_path }}/build/openssl-ca.cnf"
+
+- name: Create root CA certificate and key
+  command: >
+    openssl req
+      -x509
+      -config "{{ role_path }}/build/openssl-ca.cnf"
+      -newkey rsa:4096
+      -sha256
+      -nodes
+      -out "{{ TLS_CA_CERT_DEST }}"
+      -keyout "{{ TLS_CA_KEY_DEST }}"
+      -outform PEM
+
+- name: Print root CA certificate
+  command: openssl x509 -in "{{ TLS_CA_CERT_DEST }}" -text -noout

--- a/roles/tls-create-ca/templates/openssl-ca.cnf.j2
+++ b/roles/tls-create-ca/templates/openssl-ca.cnf.j2
@@ -1,0 +1,24 @@
+RANDFILE        = $ENV::HOME/.rnd
+
+[ req ]
+prompt = no
+default_bits        = 4096
+default_keyfile     = cakey.pem
+distinguished_name  = ca_distinguished_name
+x509_extensions     = ca_extensions
+string_mask         = utf8only
+
+[ ca_distinguished_name ]
+C            = {{ COUNTRY_NAME           | default('US') }}
+ST           = {{ STATE_OR_PROVINCE_NAME | default('Arizona') }}
+L            = {{ LOCALITY_NAME          | default('Tucson') }}
+O            = {{ ORGANIZATION_NAME      | default('Organisation Name') }}
+OU           = {{ ORG_UNIT_NAME          | default('Organisation Division') }}
+CN           = {{ COMMON_NAME            | default('Common Name CA') }}
+emailAddress = {{ EMAIL_ADDRESS          | default('test@example.com') }}
+
+[ ca_extensions ]
+subjectKeyIdentifier   = hash
+authorityKeyIdentifier = keyid:always, issuer
+basicConstraints       = critical, CA:true
+keyUsage               = keyCertSign, cRLSign

--- a/roles/tls-create-csr/README.md
+++ b/roles/tls-create-csr/README.md
@@ -1,0 +1,48 @@
+tls-create-csr
+=========
+
+Create a certificate signing request
+
+The intention is that this playbook will **not** be used in production. It is
+useful for local development but is otherwise a major liability.
+
+Role Variables
+--------------
+
+There are two ways to set the necessary variables. If you're not sure what to
+do just fill out this `DOMAIN_NAME` and the role will spit out
+`server_cert_csr.pem` and `server_cert_key.pem` which are respectively the
+cert request and private key for the cert awaiting to be signed.
+
+| Variable                      | Required       | Default               | Choices       | Comment                                         |
+|-------------------------------|----------------|-----------------------|---------------|-------------------------------------------------|
+| DOMAIN_NAME                   | yes            |                       |               | Should be the fully qualified domain name       |
+| TLS_CERT_REQUEST_DEST         | no             | server_cert_csr.pem   |               | Path to generated cert signing request          |
+| TLS_CERT_PRIVATE_KEY_DEST     | no             | server_cert_key.pem   |               | Path to generated cert key                      |
+
+Another route is to specify all of the following variables.
+
+| Variable                        | Required          | Default                     | Choices       | Comment                                    |
+|---------------------------------|-------------------|-----------------------------|---------------|--------------------------------------------|
+| TLS_CERT_REQUEST_DEST           | no                | server_cert_csr.pem         |               | Path to generated cert signing request     |
+| TLS_CERT_PRIVATE_KEY_DEST       | no                | server_cert_key.pem         |               | Path to generated cert key                 |
+| COUNTRY_NAME                    | no                | US                          |               |                                            |
+| STATE_OR_PROVINCE_NAME          | no                | Arizona                     |               |                                            |
+| LOCALITY_NAME                   | no                | Tucson                      |               |                                            |
+| ORGANIZATION_NAME               | no                | Organisation Name           |               |                                            |
+| ORG_UNIT_NAME                   | no                | Organisation Division       |               |                                            |
+| COMMON_NAME                     | no                | DOMAIN_NAME                 |               | If missing, requires DOMAIN_NAME           |
+| EMAIL_ADDRESS                   | no                | test@example.com            |               |                                            |
+| DNS_1                           | no                | DOMAIN_NAME                 |               | If missing, requires DOMAIN_NAME           |
+| DNS_2                           | no                |                             |               |                                            |
+| DNS_3                           | no                |                             |               |                                            |
+| DNS_4                           | no                |                             |               |                                            |
+
+Example Playbook
+----------------
+
+    - hosts: localhost
+      roles:
+       - { role: tls-create-ca, DOMAIN_NAME: local.atmo.cloud }
+
+https://cyverse.org

--- a/roles/tls-create-csr/defaults/main.yml
+++ b/roles/tls-create-csr/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+TLS_CERT_REQUEST_DEST: server_cert_csr.pem
+TLS_CERT_PRIVATE_KEY_DEST: server_cert_key.pem

--- a/roles/tls-create-csr/tasks/main.yml
+++ b/roles/tls-create-csr/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Create a directory to store temporary files
+  file:
+    path: "{{ role_path }}/build"
+    state: directory
+
+- template:
+    src: "{{ role_path }}/templates/openssl-server.cnf.j2"
+    dest: "{{ role_path }}/build/openssl-server.cnf"
+
+- name: Make a certificate signing request
+  command: >
+    openssl req
+      -config "{{ role_path }}/build/openssl-server.cnf"
+      -newkey rsa:4096
+      -sha256
+      -nodes
+      -out "{{ TLS_CERT_REQUEST_DEST }}"
+      -keyout "{{ TLS_CERT_PRIVATE_KEY_DEST }}"
+      -outform PEM

--- a/roles/tls-create-csr/templates/openssl-server.cnf.j2
+++ b/roles/tls-create-csr/templates/openssl-server.cnf.j2
@@ -1,0 +1,35 @@
+RANDFILE = $ENV::HOME/.rnd
+
+[ req ]
+prompt = no
+distinguished_name = server_distinguished_name
+req_extensions     = server_req_extensions
+string_mask        = utf8only
+
+[ server_distinguished_name ]
+C            = {{ COUNTRY_NAME           | default('US') }}
+ST           = {{ STATE_OR_PROVINCE_NAME | default('Arizona') }}
+L            = {{ LOCALITY_NAME          | default('Tucson') }}
+O            = {{ ORG_NAME               | default('Organization Name') }}
+OU           = {{ ORG_UNIT_NAME          | default('Organization Division') }}
+CN           = {{ COMMON_NAME            | default(DOMAIN_NAME) }}
+emailAddress = {{ EMAIL_ADDRESS          | default('test@example.com') }}
+
+[ server_req_extensions ]
+subjectKeyIdentifier = hash
+basicConstraints     = CA:FALSE
+keyUsage             = digitalSignature, keyEncipherment
+subjectAltName       = @alternate_names
+nsComment            = "OpenSSL Generated Certificate"
+
+[ alternate_names ]
+DNS.1 = {{ DNS_1 | default(DOMAIN_NAME) }}
+{% if DNS_2 is defined %}
+DNS.2 = {{ DNS_2 }}
+{% endif %}
+{% if DNS_3 is defined %}
+DNS.3 = {{ DNS_3 }}
+{% endif %}
+{% if DNS_4 is defined %}
+DNS.4 = {{ DNS_4 }}
+{% endif %}


### PR DESCRIPTION
This PR includes a utility playbook to create a certificate authority (CA) and certificates signed by said authority. Here is the associated [documenation](https://github.com/cdosborn/clank/blob/6dcec30b23013f83a26aa77754085020c2867849/playbooks/utils/create_ca_and_cert_README.md).

I think there are several reasons why this work offers improvements over our current solution:
- It works for developers outside our organization
- There is no sharing of certs and keys
- The certs don't expire (mostly true)

This pr depends on #175. That should be merged first.