### PR TITLE
Fix self-signed certificate failures in Chrome (v58)

### DIFF
--- a/playbooks/deploy_atmosphere.yml
+++ b/playbooks/deploy_atmosphere.yml
@@ -16,6 +16,7 @@
         tags: ['dependencies', 'database'] }
 
     - { role: tls-cert,
+        TLS_SUBJECT_ALTERNATE_NAME: "{{ atmosphere_server_name }}",
         tags: ['dependencies', 'ssl'] }
 
 - name: Clone Atmosphere Ansible

--- a/playbooks/deploy_troposphere.yml
+++ b/playbooks/deploy_troposphere.yml
@@ -15,6 +15,7 @@
         tags: ['dependencies', 'database'] }
 
     - { role: tls-cert,
+        TLS_SUBJECT_ALTERNATE_NAME: "{{ troposphere_server_name }}",
         when: clean_target,
         tags: ['dependencies', 'ssl'] }
 

--- a/playbooks/utils/create_ca_and_cert.yml
+++ b/playbooks/utils/create_ca_and_cert.yml
@@ -1,12 +1,12 @@
 ---
 - hosts: all
   vars:
-       TLS_CA_CERT_DEST: "./{{ SERVER_NAME }}.ca.cert.pem"
-       TLS_CA_KEY_DEST: "./{{ SERVER_NAME }}.ca.key.pem"
-       TLS_CERT_REQUEST_DEST: "./{{ SERVER_NAME }}.server.csr.pem"
-       TLS_CERT_PRIVATE_KEY_DEST: "./{{ SERVER_NAME }}.server.key.pem"
-       TLS_SIGNED_CERT_DEST: "./{{ SERVER_NAME }}.server.cert.pem"
+       TLS_CA_CERT_DEST: "./{{ server_name }}.ca.cert.pem"
+       TLS_CA_KEY_DEST: "./{{ server_name }}.ca.key.pem"
+       TLS_CERT_REQUEST_DEST: "./{{ server_name }}.server.csr.pem"
+       TLS_CERT_PRIVATE_KEY_DEST: "./{{ server_name }}.server.key.pem"
+       TLS_SIGNED_CERT_DEST: "./{{ server_name }}.server.cert.pem"
   roles:
-   - { role: tls-create-ca, DOMAIN_NAME: "{{ SERVER_NAME }} CA" }
-   - { role: tls-create-csr, DOMAIN_NAME: "{{ SERVER_NAME }}" }
+   - { role: tls-create-ca, DOMAIN_NAME: "{{ server_name }} CA" }
+   - { role: tls-create-csr, DOMAIN_NAME: "{{ server_name }}" }
    - tls-ca-sign-csr

--- a/roles/tls-cert/README.md
+++ b/roles/tls-cert/README.md
@@ -1,8 +1,8 @@
 TLS Certificate
 =========
 
-Does one of two things depending on configuration:
-- Installs your TLS certificate, private key, and CA certificate bundle to target system.
+Installs TLS (SSL) certificates to the target, in one of two ways depending on configuration:
+- Installs your provided TLS certificate, private key, and CA certificate bundle to target system.
 - Deploys a new self-signed certificate + key to target system.
 
 In either case, automatically creates a "full chain" file (containing certificate + CA bundle, suitable for use with Nginx) as well.
@@ -26,17 +26,21 @@ If using this role to create and deploy a self-signed certificate then `openssl`
 Role Variables
 --------------
 
-| Variable                | Required | Default             | Choices     | Comments                                   |
-|-------------------------|----------|---------------------|-------------|--------------------------------------------|
-| TLS_PRIVKEY_SRC_FILE    | no       |                     |             | Path to private key on deployer system     |
-| TLS_CERT_SRC_FILE       | no       |                     |             | Path to certificate on deployer system     |
-| TLS_CACHAIN_SRC_FILE    | no       |                     |             | Path to CA chain on deployer system        |
-| TLS_DEST_BASENAME       | no       | provided cert CN*   |             | Base filename of installed certificate     |
-| TLS_CREATE_SELFSIGNED   | no       | false               | true, false | Explicitly creates self-signed certificate |
-| TLS_CERT_DEST_DIR       | no       | (distro-specific)   |             | Directory for certificates on target host  |
-| TLS_PRIVKEY_DEST_DIR    | no       | (distro-specific)   |             | Directory for private keys on target host  |
+| Variable                          | Required       | Default                   | Choices           | Comments                                         |
+|-----------------------------------|----------------|---------------------------|-------------------|--------------------------------------------------|
+| TLS_PRIVKEY_SRC_FILE              | no             |                           |                   | Path to private key on deployer system           |
+| TLS_CERT_SRC_FILE                 | no             |                           |                   | Path to certificate on deployer system           |
+| TLS_CACHAIN_SRC_FILE              | no             |                           |                   | Path to CA chain on deployer system              |
+| TLS_DEST_BASENAME                 | no             | provided cert CN*         |                   | Base filename of installed certificate           |
+| TLS_CREATE_SELFSIGNED             | no             | false                     | true, false       | Explicitly creates self-signed certificate       |
+| TLS_CERT_DEST_DIR                 | no             | (distro-specific)         |                   | Directory for certificates on target host        |
+| TLS_PRIVKEY_DEST_DIR              | no             | (distro-specific)         |                   | Directory for private keys on target host        |
+| TLS_SUBJECT_ALTERNATE_NAME        | depends        |                           |                   | The fully qualified domain name, only required   |
+|                                   |                |                           |                   | if creating a self-signed cert                   |
 
 If you specify at least a TLS_PRIVKEY_SRC_FILE, TLS_CERT_SRC_FILE, and TLS_CACHAIN_SRC_FILE, then the provided files will be installed to the target. (Ansible will look in "files" directory relative to playbook if you specify a bare filename or relative path.) If these variables are not set by the deployer, then the role will create a self-signed certificate instead, with files selfsigned.crt and selfsigned.key. You can explicitly set `TLS_CREATE_SELFSIGNED: true` to override the default behavior and force creation of a self-signed certificate.
+
+**In order to create a valid self-signed certificate, you must provide `TLS_SUBJECT_ALTERNATE_NAME`**. The Subject Alternate Name (SAN) is the field in the generated certificate which indicates the server's hostname. A valid example would be 'local.atmo.cloud'. The Chrome browser recently made this field mandatory. If you would like to learn about the history read this SO [answer](http://stackoverflow.com/a/14648100/1213041).
 
 `*` If the deployer provides a certificate, then the certificate's indicated CN (domain) will be used as the base name of the files on the target (e.g. `example.com.key`, `example.com.crt`, `example.com.cachain.crt`, and `example.com.fullchain.crt` for example.com). If this role creates a self-signed certificate, the files will be named with "selfsigned" as the base name. In either case, setting `TLS_DEST_BASENAME` overrides this filename.
 

--- a/roles/tls-cert/meta/.galaxy_install_info
+++ b/roles/tls-cert/meta/.galaxy_install_info
@@ -1,1 +1,1 @@
-{install_date: 'Fri Jan 13 22:55:04 2017', version: master}
+{install_date: 'Fri May 19 23:11:50 2017', version: master}

--- a/roles/tls-cert/tasks/deploy-selfsigned.yml
+++ b/roles/tls-cert/tasks/deploy-selfsigned.yml
@@ -1,4 +1,12 @@
 ---
+- name: Create a directory to store temporary files
+  file:
+    path: "{{ role_path }}/build"
+    state: directory
+
+- template:
+    src: "{{ role_path }}/templates/openssl-req.cnf.j2"
+    dest: "{{ role_path }}/build/openssl-req.cnf"
 
 - name: TLS_DEST_BASENAME set to "selfsigned" if not already overridden
   set_fact:
@@ -8,12 +16,12 @@
 - name: Self-signed certificate and private key created
   tags: [selfsigned-cert-created]
   command: >
-    openssl req -new
+    openssl req
+    -config "{{ role_path }}/build/openssl-req.cnf"
+    -newkey rsa:2048
     -x509
     -nodes
-    -extensions v3_ca
     -days 3650
-    -subj "/"
     -keyout {{ TLS_PRIVKEY_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.key
     -out {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt
   args:

--- a/roles/tls-cert/tasks/deploy-selfsigned.yml
+++ b/roles/tls-cert/tasks/deploy-selfsigned.yml
@@ -24,8 +24,6 @@
     -days 3650
     -keyout {{ TLS_PRIVKEY_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.key
     -out {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt
-  args:
-    creates: "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt"
 
 - name: Empty CA chain file created
   tags: [selfsigned-empty-bundle-created]

--- a/roles/tls-cert/templates/openssl-req.cnf.j2
+++ b/roles/tls-cert/templates/openssl-req.cnf.j2
@@ -1,0 +1,27 @@
+RANDFILE = $ENV::HOME/.rnd
+
+[ req ]
+prompt = no
+distinguished_name = server_distinguished_name
+x509_extensions    = server_req_extensions
+string_mask        = utf8only
+
+[ server_distinguished_name ]
+C            = 'US'
+ST           = 'Arizona')
+L            = 'Tucson')
+O            = 'Organization Name')
+OU           = 'Organization Division')
+CN           = {{ TLS_SUBJECT_ALTERNATE_NAME }}
+emailAddress = 'test@example.com'
+
+[ server_req_extensions ]
+authorityKeyIdentifier = keyid,issuer
+subjectKeyIdentifier   = hash
+basicConstraints       = CA:FALSE
+keyUsage               = digitalSignature, keyEncipherment
+subjectAltName         = @alternate_names
+nsComment              = "OpenSSL Generated Certificate"
+
+[ alternate_names ]
+DNS.1 = {{ TLS_SUBJECT_ALTERNATE_NAME }}


### PR DESCRIPTION
The description/problem can be found here https://github.com/CyVerse-Ansible/ansible-tls-cert/pull/5. 

The second commit fixes the issue where certs never get **re**generated. 