### PR TITLE
Remove jinja syntax from conditionals

### DIFF
--- a/playbooks/setup_atmosphere.yml
+++ b/playbooks/setup_atmosphere.yml
@@ -10,12 +10,12 @@
         DBNAME: "{{ ATMO_DBNAME | default(atmosphere_database_name) }}",
         DBUSER: "{{ ATMO_DBUSER | default(atmosphere_database_user) }}",
         DBPASSWORD: "{{ ATMO_DBPASSWORD | default(atmosphere_database_password) }}",
-        LOAD_DATABASE: "{{ ATMO_DATA.LOAD_DATABASE | default(False) }}",
+        LOAD_DATABASE: "ATMO_DATA.LOAD_DATABASE | default(False)",
         tags: ['atmosphere', 'database'] }
 
     - { role: app-load-data-postgres,
         DBNAME: "{{ ATMO_DBNAME | default(atmosphere_database_name) }}",
-        LOAD_DATABASE: "{{ ATMO_DATA.LOAD_DATABASE | default(False) }}",
+        LOAD_DATABASE: "ATMO_DATA.LOAD_DATABASE | default(False)",
         DATABASE_FILE_TO_BE_LOADED: "{{ ATMO_DATA.SQL_DUMP_FILE }}",
         when: ATMO_DATA is defined and ATMO_DATA.SQL_DUMP_FILE is defined and ATMO_DATA.LOAD_DATABASE is defined,
         tags: ['atmosphere', 'data-load'] }

--- a/roles/app-pip-install-requirements/tasks/main.yml
+++ b/roles/app-pip-install-requirements/tasks/main.yml
@@ -6,7 +6,7 @@
     - pip
 
 - name: pip install requirements
-  when: not "{{ USE_PIP_TOOLS_SYNC | default(False) }}"
+  when: not "USE_PIP_TOOLS_SYNC | default(False)"
   pip: >
     chdir={{ APP_BASE_DIR }}
     requirements={{ REQUIREMENTS_FILE_NAME }}


### PR DESCRIPTION
As of Ansible 2.3, conditonal statements that use the full Jinja2 templating syntax with filters cause errors. The full variable syntax is not required in Ansible, **only** in the `when:` lines, so removing the `{{ }}` fixed the error but maintains the functionality of having defaults.

[ATMO-1894](https://pods.iplantcollaborative.org/jira/browse/ATMO-1894)

Example of error:
```
TASK [app-pip-install-requirements : pip install requirements] *************************************
Wednesday 07 June 2017  13:22:49 -0700 (0:00:01.298)       0:00:38.084 ********
 [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}.
Found: not "{{ USE_PIP_TOOLS_SYNC | default(False) }}"
```