### PR TITLE
Use older trusty box that has working apt repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@
   sudo: required
   dist: trusty
 
+  # Use an older version of trusty until quirks are figured out. 
+  # https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch
+  group: deprecated-2017Q2
+
   language: python
   python: "2.7"
 

--- a/playbooks/deploy_atmosphere.yml
+++ b/playbooks/deploy_atmosphere.yml
@@ -1,6 +1,5 @@
 ---
 - name: Install and setup required dependencies for Atmosphere
-  strategy: debug
   hosts: atmosphere
   vars:
     clean_target: CLEAN_TARGET | default(True)

--- a/playbooks/deploy_stack.yml
+++ b/playbooks/deploy_stack.yml
@@ -1,6 +1,5 @@
 ---
 - name: Create an Atmosphere and Troposphere stack
-  strategy: debug
   hosts: full_deploy
 
   roles:


### PR DESCRIPTION
Problem: broken clank build
Solution: Don't use the brand new buggy trusty image released yesterday

Yesterday travis rolled out a new trusty image that was broken. Ansible was
failing to add repositories because the trusty image had a broken repository
in its list.

https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch