### PR TITLE
Install only dev deps in clank

### DIFF
--- a/playbooks/setup_atmosphere.yml
+++ b/playbooks/setup_atmosphere.yml
@@ -36,7 +36,7 @@
 
     - { role: app-pip-install-requirements,
         APP_BASE_DIR: "{{ ATMOSPHERE_LOCATION | default(atmosphere_directory_path) }}",
-        REQUIREMENTS_FILE_NAME: 'requirements.txt dev_requirements.txt',
+        REQUIREMENTS_FILE_NAME: 'dev_requirements.txt',
         USE_PIP_TOOLS_SYNC: True,
         VIRTUAL_ENV: "{{ VIRTUAL_ENV_ATMOSPHERE | default(atmosphere_virtualenv_path) }}",
         PIP_EXTRA_ARGS: '{% if faster_dev_rebuild == false %}--no-cache-dir {% endif %}--no-binary pycparser',

--- a/playbooks/setup_troposphere.yml
+++ b/playbooks/setup_troposphere.yml
@@ -32,7 +32,7 @@
 
     - { role: app-pip-install-requirements,
         APP_BASE_DIR: "{{ TROPOSPHERE_LOCATION | default(troposphere_directory_path) }}",
-        REQUIREMENTS_FILE_NAME: 'requirements.txt dev_requirements.txt',
+        REQUIREMENTS_FILE_NAME: 'dev_requirements.txt',
         USE_PIP_TOOLS_SYNC: True,
         VIRTUAL_ENV: "{{ VIRTUAL_ENV_TROPOSPHERE | default(troposphere_virtualenv_path) }}",
         PIP_EXTRA_ARGS: '{% if faster_dev_rebuild == false %}--no-cache-dir {% endif %}--no-binary pycparser',


### PR DESCRIPTION
Remove redundant install of requirements.
`pip install requirements.txt dev_requirements.txt` is redundant because dev_requirements.txt contains requirements.txt. 

depends on #187 (already merged)
depends on https://github.com/cyverse/troposphere/pull/629 (already merged in z-z)
depends on https://github.com/cyverse/atmosphere/pull/399

**Note:**
I think travis builds clank against tropo/atmo master, so we need the above prs to not only go into z-z but also into master.
