### PR TITLE
Problem: number of uWSGI processes not configurable

### DIFF
--- a/group_vars/atmosphere
+++ b/group_vars/atmosphere
@@ -13,13 +13,14 @@ atmosphere_virtualenv_path: "{{ VIRTUAL_ENV_ATMOSPHERE | default(virtualenv_dir+
 atmosphere_server_name: "{{ server_name }}"
 atmosphere_server_url: "https://{{ atmosphere_server_name }}"
 
-SENTRY_DICT: "{{ SENTRY | default({}) }}"
-
 ###################################
 #
 # ATMOSPHERE VARS
 #
 ###################################
+
+SENTRY_DICT: "{{ SENTRY | default({}) }}"
+
 ATMO_LOG_FILES:
   - 'atmosphere.log'
   - 'atmosphere_status.log'

--- a/group_vars/atmosphere
+++ b/group_vars/atmosphere
@@ -12,6 +12,7 @@ atmosphere_directory_path: "{{workspace}}/{{atmosphere_directory_name}}"
 atmosphere_virtualenv_path: "{{ VIRTUAL_ENV_ATMOSPHERE | default(virtualenv_dir+'/'+atmosphere_virtualenv_name) }}"
 atmosphere_server_name: "{{ server_name }}"
 atmosphere_server_url: "https://{{ atmosphere_server_name }}"
+atmosphere_uwsgi_processes: 24
 
 ###################################
 #
@@ -49,6 +50,7 @@ ATMO:
         LOCAL_DEV: False
         PATH_TO_ATMOSPHERE: "{{ ATMOSPHERE_LOCATION | default(atmosphere_directory_path) }}"
         VIRTUALENV_PATH: "{{ atmosphere_virtualenv_path }}"
+        NUM_PROCESSES: "{{ atmosphere_uwsgi_processes }}"
         UWSGI_USER: www-data
         UWSGI_GROUP: www-data
         UWSGI_LOG_PATH: /var/log/uwsgi/atmosphere-uwsgi.log

--- a/group_vars/troposphere
+++ b/group_vars/troposphere
@@ -11,6 +11,7 @@ troposphere_directory_path: "{{workspace}}/{{troposphere_directory_name}}"
 troposphere_build: development
 troposphere_server_name: "{{ server_name }}"
 troposphere_server_url: "https://{{ troposphere_server_name }}"
+troposphere_uwsgi_processes: 12
 
 ###################################
 #
@@ -59,6 +60,7 @@ TROPO:
         LOCAL_DEV: False
         PATH_TO_TROPOSPHERE: "{{ TROPOSPHERE_LOCATION | default(troposphere_directory_path) }}"
         VIRTUALENV_PATH: "{{ VIRTUAL_ENV_TROPOSPHERE | default(troposphere_virtualenv_path) }}"
+        NUM_PROCESSES: "{{ troposphere_uwsgi_processes }}"
         UWSGI_USER: www-data
         UWSGI_GROUP: www-data
         UWSGI_LOG_PATH: /var/log/uwsgi/troposphere-uwsgi.log


### PR DESCRIPTION
## Description

Different environment will need to tune the number of uWSGI processes for handling requests. 

This work makes `NUM_PROCESSES` a variable within the `uwsgi.ini` variables section, and allows for _override_ variables to be defined for Atmosphere and Troposphere.

### Override Variables:

These variables can be overridden within a `variables.yml` build environment file:

- `atmosphere_uwsgi_processes`
- `troposphere_uwsgi_processes`

This depends on `NUM_PROCESSES` being introduced within Atmosphere and Troposphere as well.:
- [cyverse/atmosphere pull request 401](https://github.com/cyverse/atmosphere/pull/401)
- [cyverse/troposphere pull request 640](https://github.com/cyverse/troposphere/pull/640)
