### PR TITLE
Problem: Django cache directory should be owned by www-data

### DIFF
--- a/roles/setup-webserver-user-group/defaults/main.yml
+++ b/roles/setup-webserver-user-group/defaults/main.yml
@@ -2,3 +2,4 @@
 # defaults file for setup-webserver-user-group
 
 WEBSERVER_USER: www-data
+DJANGO_CACHE_DIRECTORY: /var/tmp/django_cache/

--- a/roles/setup-webserver-user-group/tasks/main.yml
+++ b/roles/setup-webserver-user-group/tasks/main.yml
@@ -13,6 +13,9 @@
 - name: add webserver-user for user and group permissions
   file: path={{ APP_BASE_DIR }} owner={{ WEBSERVER_USER }} group={{ WEBSERVER_USER }} mode="g+rw" recurse=yes
 
+- name: Allow webserver-user read & write permissions on the Django cache directory
+  file: path={{ DJANGO_CACHE_DIRECTORY }} state=directory owner={{ WEBSERVER_USER }} group={{ WEBSERVER_USER }} mode="g+rw" recurse=yes
+
 - name: Register variable to determine if user vagrant exists
   shell: /usr/bin/getent passwd vagrant | awk -F":" '{print $1}'
   register: vagrant_exists


### PR DESCRIPTION
Otherwise you get errors like these:

```
IOError: [Errno 13] Permission denied: '/var/tmp/django_cache/96b2eeef9dbbd9d34340463b78cbd10b.djcache'
```

Solution: Set the correct permissions. Also create this directory if it
doesn't exist.