### PR TITLE
Problem: allocation units appear with extra 's' at end

### DIFF
--- a/group_vars/troposphere
+++ b/group_vars/troposphere
@@ -144,7 +144,7 @@ TROPO:
 
         USE_ALLOCATION_SOURCES: "{{ USE_ALLOCATION_SOURCE | default(False) }}"
         EXTERNAL_ALLOCATION: "{{ EXTERNAL_ALLOCATION | default(True) }}"
-        ALLOCATION_UNIT_NAME: "{{ ALLOCATION_UNIT_NAME | default('Allocation Units') }}"
+        ALLOCATION_UNIT_NAME: "{{ ALLOCATION_UNIT_NAME | default('Allocation Unit') }}"
         ALLOCATION_UNIT_ABBREV: "{{ ALLOCATION_UNIT_ABBREV | default('AU') }}"
         USE_MOCK_DATA: "{{ USE_MOCK_DATA | default(False) }}"
         USE_GATE_ONE_API: "{{ USE_GATE_ONE_API | default(False) }}"


### PR DESCRIPTION
The Allocation Unit name is already pluralized, inline, where used. We can re-evaluate this when an Internationalization (i18n) effort is done.