### PR TITLE
Reporting SQL access

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ cd clank
 
 An example of the [`$VARIABLES_YML_FILE`](dist_files/variables.yml.dist) can be found in the [dist_files](dist_files) directory.
 
+### Optional Extra Functionality
+
+Clank provides optional functionality that is used in some, but not all deployments. Enable these optional configurations by setting the corresponding variable to `true` (e.g. in your variables.yml).
+
+| **Variable**               | **Purpose**                                                       |
+|----------------------------|-------------------------------------------------------------------|
+| SETUP_REPORTING_SQL_ACCESS | external read-only access to subset of DB for reporting/analytics |
+
 ### Running Portions of Clank
 
 [WIP] -- All of clank should be re-evaluated to ensure that the 3 'supported tags' listed below cover enough ground. For now, ignore this section. -- [WIP]
@@ -105,7 +113,7 @@ We recomened copying the `defaultThemeImages` folder found in Troposphere
 `<projectRoot>/troposphere/static/theme/themeImagesDefault`
 
 Replace any image in the folder with your new image keeping the same name and file type. It is important that the new image has the same dimensions and uses a transparent background or it may not display correctly. Your image may not be the same ratio as the image you are replacing but the file should be. For example, your logo might be shorter in length given the same height. Without distorting the logo ratio, align it to the left of the file and export the file at the same dimensions of the original file.
- 
+
 
 ```
 File Dimentions

--- a/playbooks/post_deployment.yml
+++ b/playbooks/post_deployment.yml
@@ -3,6 +3,9 @@
   hosts: all
   roles:
     - { role: atmosphere-include-startup,
-        tags: ['post-install','atmosphere'] }
+        tags: ['atmosphere'] }
+    - { role: reporting-sql-access,
+        tags: ['reporting-sql-access'],
+        when: SETUP_REPORTING_SQL_ACCESS is defined and SETUP_REPORTING_SQL_ACCESS == true }
   tags:
     - post-install

--- a/roles/reporting-sql-access/README.md
+++ b/roles/reporting-sql-access/README.md
@@ -1,0 +1,37 @@
+Reporting SQL Access for Atmosphere(2)
+=========
+
+Configures external read-only access to a subset of Atmosphere database (excluding secrets) for reporting/analytics purposes.
+
+- `reporting` PostgreSQL role with read-only access to all information in Atmosphere database, except columns/tables containing 'sensitive' information
+- Key-authed SSH access allowed as `reporting` unix user
+- `reporting` unix user with login shell set to run script which dumps DB to stdout
+
+Allow your data scientists/analysts to run `ssh reporting@my.atmo.cloud > db-dump.sql` and obtain a near-complete dump of Atmosphere(2) database for reporting/analytics purposes. They can take a live dump of production at any time without exposing secrets or obtaining any other kind of access to production environment. Using SSH in this way allows us to avoid exposing PostgreSQL server to the world (and worrying about PostgreSQL password auth, TLS, etc).
+
+Role Variables
+--------------
+
+| Variable                  | Required | Default | Choices | Comments                                        |
+|---------------------------|----------|---------|---------|-------------------------------------------------|
+| atmosphere_database_name  | yes      |         |         | Should already be defined in clank vars         |
+| reporting_access_ssh_keys | yes      |         |         | List of SSH public keys to get reporting access |
+
+
+Example Playbook
+----------------
+
+    - hosts: all
+      roles:
+         - reporting-sql-access
+
+License
+-------
+
+See license.md
+
+Author Information
+------------------
+
+Chris Martin
+https://cyverse.org

--- a/roles/reporting-sql-access/tasks/main.yml
+++ b/roles/reporting-sql-access/tasks/main.yml
@@ -1,0 +1,96 @@
+---
+
+- name: OS-Specific variables gathered
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
+    - "{{ ansible_distribution }}.yml"
+
+# Dependencies
+
+- name: psycopg2 installed
+  package:
+    name: '{{ psycopg2_package }}'
+    state: 'installed'
+
+# SQL setup
+
+- name: Reporting PostgreSQL role created
+  postgresql_user:
+    db: '{{ atmosphere_database_name }}'
+    name: 'reporting'
+    role_attr_flags: 'NOSUPERUSER,INHERIT,NOCREATEDB,NOCREATEROLE,NOREPLICATION'
+  become: true
+  become_user: 'postgres'
+
+- name: Privileges granted to reporting PostgreSQL role
+  postgresql_privs:
+    database: '{{ atmosphere_database_name }}'
+    grant_option: 'no'
+    privs: '{{ item.privs }}'
+    objs: '{{ item.objs }}'
+    type: '{{ item.type }}'
+    roles: 'reporting'
+  with_items:
+    - objs: ''
+      privs: 'CONNECT'
+      type: 'database'
+    - objs: 'public'
+      privs: 'USAGE,CREATE'
+      type: 'schema'
+    - objs: 'ALL_IN_SCHEMA'
+      privs: 'SELECT'
+      type: 'table'
+    - objs: 'ALL_IN_SCHEMA'
+      privs: 'SELECT'
+      type: 'sequence'
+  become: true
+  become_user: 'postgres'
+
+- name: Privileges revoked from reporting PostgreSQL role for sensitive tables
+  postgresql_privs:
+    database: '{{ atmosphere_database_name }}'
+    grant_option: 'no'
+    privs: 'SELECT'
+    objs: 'access_token,atmosphere_user,auth_token,auth_userproxy,boot_script,credential,django_admin_log,django_cyverse_auth_accesstoken,django_cyverse_auth_token,django_cyverse_auth_userproxy,django_session,external_link,iplantauth_accesstoken,iplantauth_token,iplantauth_userproxy,node_controller,provider,provider_credential'
+    type: 'table'
+    state: absent
+    roles: 'reporting'
+  become: true
+  become_user: 'postgres'
+
+- name: Privileges granted to reporting PostgreSQL role for specific columns in tables with sensitive data
+  command: 'psql {{ atmosphere_database_name }} postgres -c "{{ item }}"'
+  with_items:
+    - 'GRANT SELECT (id, last_login, is_superuser, username, first_name, last_name, email, is_staff, is_active, date_joined, selected_identity_id, uuid, end_date) ON atmosphere_user TO reporting;'
+    - 'GRANT SELECT (id, location, type_id, active, public, start_date, end_date, virtualization_id, description, auto_imaging, over_allocation_action_id, uuid, timezone, cloud_admin_id) ON provider TO reporting;'
+  become: true
+  become_user: 'postgres'
+
+# Unix user
+
+- name: Reporting user created
+  user:
+    name: 'reporting'
+    # CyVerse convention, allows SSH access as user
+    groups: 'users'
+    shell: '/home/reporting/dump-db.sh'
+
+- name: Authorized keys to SSH in and take DB dump
+  authorized_key:
+    user: 'reporting'
+    state: 'present'
+    key: '{{ item }}'
+  with_items: '{{ reporting_access_ssh_keys }}'
+
+- name: MOTD suppressed for reporting user
+  file:
+    path: '/home/reporting/.hushlogin'
+    state: 'touch'
+
+- name: DB dump script deployed
+  template:
+    src: 'dump-db.sh.j2'
+    dest: '/home/reporting/dump-db.sh'
+    owner: 'reporting'
+    mode: 'u+x'

--- a/roles/reporting-sql-access/templates/dump-db.sh.j2
+++ b/roles/reporting-sql-access/templates/dump-db.sh.j2
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+psql {{ atmosphere_database_name }} > /dev/null << EOF
+CREATE TABLE atmosphere_user_reporting AS SELECT id, last_login, is_superuser, username, first_name, last_name, email, is_staff, is_active, date_joined, selected_identity_id, uuid, end_date FROM atmosphere_user;
+CREATE TABLE provider_reporting AS SELECT id, location, type_id, active, public, start_date, end_date, virtualization_id, description, auto_imaging, over_allocation_action_id, uuid, timezone, cloud_admin_id FROM provider;
+EOF
+
+/usr/bin/pg_dump -T access_token -T atmosphere_user -T auth_token -T auth_userproxy -T boot_script -T credential -T django_admin_log -T django_cyverse_auth_accesstoken -T django_cyverse_auth_token -T django_cyverse_auth_userproxy -T django_session -T external_link -T iplantauth_accesstoken -T iplantauth_token -T iplantauth_userproxy -T node_controller -T provider -T provider_credential atmo_prod
+
+psql atmo_prod > /dev/null << EOF
+DROP TABLE atmosphere_user_reporting, provider_reporting;
+EOF

--- a/roles/reporting-sql-access/vars/Ubuntu.yml
+++ b/roles/reporting-sql-access/vars/Ubuntu.yml
@@ -1,0 +1,3 @@
+---
+
+psycopg2_package: 'python-psycopg2'


### PR DESCRIPTION
From `README.md` of the new role:

Configures external read-only access to a subset of Atmosphere database (excluding secrets) for reporting/analytics purposes.

- `reporting` PostgreSQL role with read-only access to all information in Atmosphere database, except columns/tables containing 'sensitive' information
- Key-authed SSH access allowed as `reporting` unix user
- `reporting` unix user with login shell set to run script which dumps DB to stdout

Allow your data scientists/analysts to run `ssh reporting@my.atmo.cloud > db-dump.sql` and obtain a near-complete dump of Atmosphere(2) database for reporting/analytics purposes. They can take a live dump of production at any time without exposing secrets or obtaining any other kind of access to production environment. Using SSH in this way allows us to avoid exposing PostgreSQL server to the world (and worrying about PostgreSQL password auth, TLS, etc).