### PR TITLE
Support for django-prometheus

### DIFF
--- a/dist_files/variables.yml.dist
+++ b/dist_files/variables.yml.dist
@@ -154,7 +154,7 @@ AUTH_MOCK_USER: "atmosphere_user"
 
 ###
 # THEME_IMAGES_PATH, expects an absolute path to an images directory
-# We recommend making a copy of the themeImagesDefault directory in Troposphere 
+# We recommend making a copy of the themeImagesDefault directory in Troposphere
 # <projectDir>/troposphere/static/theme/themeImagesDefault
 # Place it in an init directory and replace any image with a new image of equal size and name
 # Uncomment the variable below.
@@ -266,6 +266,12 @@ AUTH_MOCK_USER: "atmosphere_user"
 #     TROPO_LABEL: ""
 #     ENVIRONMENT: ""
 #     BROWSER: 'partials/__new_relic_browser.html'
+
+###
+# django-prometheus
+###
+###
+# ATMO_ENABLE_DJANGO_PROMETHEUS: true
 
 ###############################
 #5. App-specific overrides

--- a/group_vars/atmosphere
+++ b/group_vars/atmosphere
@@ -187,7 +187,7 @@ ATMO:
         ENABLE_DJANGO_PROMETHEUS: "{{ ATMO_ENABLE_DJANGO_PROMETHEUS }}"
 
 
-    __init__.py:
+    init.py:
         ENABLE_DJANGO_PROMETHEUS: "{{ ATMO_ENABLE_DJANGO_PROMETHEUS }}"
 
     secrets.py:

--- a/group_vars/atmosphere
+++ b/group_vars/atmosphere
@@ -184,6 +184,12 @@ ATMO:
         WEB_DESKTOP_INCLUDE_LINK: "{{ WEB_DESKTOP_INCLUDE_LINK | default(False) }}"
         WEB_DESKTOP_PROXY_URL: "{{ WEB_DESKTOP_PROXY_URL | default('') }}"
         WEB_DESKTOP_PROXY_DOMAIN: "{{ WEB_DESKTOP_PROXY_DOMAIN | default('') }}"
+        ENABLE_DJANGO_PROMETHEUS: "{{ ATMO_ENABLE_DJANGO_PROMETHEUS }}"
+
+
+    __init__.py:
+        ENABLE_DJANGO_PROMETHEUS: "{{ ATMO_ENABLE_DJANGO_PROMETHEUS }}"
+
     secrets.py:
         IRODS_HOST: "{{ IRODS_HOST | default('') }}"
         IRODS_PORT: "{{ IRODS_PORT | default('') }}"


### PR DESCRIPTION
Adds support for [django-prometheus](https://github.com/korfuri/django-prometheus) which can be conditionally enabled by the deployer.

Co-depends on [PR #507](https://github.com/cyverse/atmosphere/pull/507) in atomsphere.