### PR TITLE
Replace overly broad vars

### DIFF
--- a/dist_files/variables.yml.dist
+++ b/dist_files/variables.yml.dist
@@ -16,8 +16,6 @@
 ###############################
 WORKSPACE: /opt/dev  #NOTE: This is where atmosphere/troposphere directories reside.
 VIRTUAL_ENV_DIR: "/opt/env"  #NOTE: This is where atmosphere/troposphere virtualenv directories reside.
-INSTALLATION_TYPE: "production"  # can be development or production
-#TODO:-- currently INSTALLATION_TYPE deals only with installing the correct requirements.txt -- but could be used to override DJANGO_JENKINS and/or celeryd
 
 ###
 # SECRETS_REPO - This repo should contain the SSH Keys, TLS certificates, and an atmosphere-ansible directory (including hosts file and group_vars directory) that you intend to use when installing Atmosphere.
@@ -307,6 +305,7 @@ AUTH_MOCK_USER: "atmosphere_user"
 ###############################
 #Uncomment for faster Clank run (you will not get very latest packages, do not use in production!)
 # faster_dev_rebuild: true
+
 #Uncomment so that virtualenvs stick around after multiple deploys (much faster build time, sometimes causes pip package issues)
 # REINSTALL_VENV: false
 
@@ -316,3 +315,8 @@ AUTH_MOCK_USER: "atmosphere_user"
 
 # Uncomment in a development environment if you want to allow self-signed certs for nginx
 # ENABLE_STRICT_TRANSPORT: false
+
+#
+# Uncomment to install development python packages (this will only add
+# additional packages to the set of production packages)
+# INSTALL_DEV_REQUIREMENTS: true

--- a/dist_files/variables.yml.dist
+++ b/dist_files/variables.yml.dist
@@ -319,3 +319,6 @@ AUTH_MOCK_USER: "atmosphere_user"
 # Uncomment to install development python packages (this will only add
 # additional packages to the set of production packages)
 # INSTALL_DEV_REQUIREMENTS: true
+
+# Uncomment so celeryd consumes less resources (fewer workers and processes)
+# CELERYD_PRODUCTION_WORKER_SETUP: false

--- a/dist_files/variables.yml.dist
+++ b/dist_files/variables.yml.dist
@@ -303,10 +303,7 @@ AUTH_MOCK_USER: "atmosphere_user"
 ###############################
 #5. Overrides for Clank Execution
 ###############################
-#Uncomment for faster Clank run (you will not get very latest packages, do not use in production!)
-# faster_dev_rebuild: true
-
-#Uncomment so that virtualenvs stick around after multiple deploys (much faster build time, sometimes causes pip package issues)
+# Uncomment so that virtualenvs stick around after multiple deploys (much faster build time, sometimes causes pip package issues)
 # REINSTALL_VENV: false
 
 # Uncomment so that uwsgi automatically reloads when atmosphere/troposphere
@@ -316,7 +313,9 @@ AUTH_MOCK_USER: "atmosphere_user"
 # Uncomment in a development environment if you want to allow self-signed certs for nginx
 # ENABLE_STRICT_TRANSPORT: false
 
-#
+# Uncomment for faster Clank run (you will not get very latest packages, do not use in production!)
+# UPDATE_DISTRO: false
+
 # Uncomment to install development python packages (this will only add
 # additional packages to the set of production packages)
 # INSTALL_DEV_REQUIREMENTS: true

--- a/group_vars/atmosphere
+++ b/group_vars/atmosphere
@@ -2,7 +2,6 @@ atmosphere_database_name: atmosphere
 atmosphere_database_password: atmosphere
 atmosphere_database_user: atmo_app
 atmosphere_directory_name: atmosphere
-celery_use_production: False
 # line below can be removed soon
 atmosphere_ansible_directory_path: "{{workspace}}/atmosphere-ansible"
 atmosphere_github_repo: https://github.com/CyVerse/atmosphere.git

--- a/group_vars/common
+++ b/group_vars/common
@@ -12,7 +12,6 @@ nginx_locations: ["atmo-uwsgi", "tropo-uwsgi", "flower", "tropo-assets-path", "r
 staff_list_usernames: "{{ STAFF_LIST_USERNAMES | default([]) }}"
 maintenance_exempt_usernames: "{{ MAINTENANCE_EXEMPT_USERNAMES | default(staff_list_usernames) }}"
 install_jenkins: "{{ DJANGO_JENKINS | default(False) }}"
-faster_dev_rebuild: false
 shallow_clone: true
 TLS_LETSENCRYPT_TLS_SERVICE: "nginx"
 FLOWER_PORT: 5555

--- a/group_vars/common
+++ b/group_vars/common
@@ -12,7 +12,6 @@ nginx_locations: ["atmo-uwsgi", "tropo-uwsgi", "flower", "tropo-assets-path", "r
 staff_list_usernames: "{{ STAFF_LIST_USERNAMES | default([]) }}"
 maintenance_exempt_usernames: "{{ MAINTENANCE_EXEMPT_USERNAMES | default(staff_list_usernames) }}"
 install_jenkins: "{{ DJANGO_JENKINS | default(False) }}"
-installation_type: "{{ INSTALLATION_TYPE | default('production') }}"
 faster_dev_rebuild: false
 shallow_clone: true
 TLS_LETSENCRYPT_TLS_SERVICE: "nginx"

--- a/playbooks/prepare_host.yml
+++ b/playbooks/prepare_host.yml
@@ -3,6 +3,6 @@
   hosts: all
   roles:
     - role: distro-update
-      when: faster_dev_rebuild == False
+      when: UPDATE_DISTRO | default(True)
   tags:
     - distro-update

--- a/playbooks/setup_atmosphere.yml
+++ b/playbooks/setup_atmosphere.yml
@@ -31,7 +31,7 @@
         VIRTUAL_ENV: "{{ VIRTUAL_ENV_ATMOSPHERE | default(atmosphere_virtualenv_path) }}",
         PIP_EXTRA_ARGS: '{% if faster_dev_rebuild == false %}--no-cache-dir {% endif %}--no-binary pycparser',
         tags: ['atmosphere', 'pip-install-requirements'],
-        when: installation_type is not defined or installation_type != 'development'}
+        when: not (INSTALL_DEV_REQUIREMENTS | default(False)) }
 
     - { role: app-pip-install-requirements,
         APP_BASE_DIR: "{{ ATMOSPHERE_LOCATION | default(atmosphere_directory_path) }}",
@@ -40,7 +40,7 @@
         VIRTUAL_ENV: "{{ VIRTUAL_ENV_ATMOSPHERE | default(atmosphere_virtualenv_path) }}",
         PIP_EXTRA_ARGS: '{% if faster_dev_rebuild == false %}--no-cache-dir {% endif %}--no-binary pycparser',
         tags: ['atmosphere', 'pip-install-requirements'],
-        when: installation_type is defined and installation_type == 'development'}
+        when: INSTALL_DEV_REQUIREMENTS | default(False) }
 
     - { role: app-config-logging,
         APP_BASE_DIR: "{{ ATMOSPHERE_LOCATION | default(atmosphere_directory_path) }}",

--- a/playbooks/setup_atmosphere.yml
+++ b/playbooks/setup_atmosphere.yml
@@ -29,7 +29,7 @@
         REQUIREMENTS_FILE_NAME: 'requirements.txt',
         USE_PIP_TOOLS_SYNC: False,
         VIRTUAL_ENV: "{{ VIRTUAL_ENV_ATMOSPHERE | default(atmosphere_virtualenv_path) }}",
-        PIP_EXTRA_ARGS: '{% if faster_dev_rebuild == false %}--no-cache-dir {% endif %}--no-binary pycparser',
+        PIP_EXTRA_ARGS: '--no-binary pycparser',
         tags: ['atmosphere', 'pip-install-requirements'],
         when: not (INSTALL_DEV_REQUIREMENTS | default(False)) }
 
@@ -38,7 +38,7 @@
         REQUIREMENTS_FILE_NAME: 'dev_requirements.txt',
         USE_PIP_TOOLS_SYNC: False,
         VIRTUAL_ENV: "{{ VIRTUAL_ENV_ATMOSPHERE | default(atmosphere_virtualenv_path) }}",
-        PIP_EXTRA_ARGS: '{% if faster_dev_rebuild == false %}--no-cache-dir {% endif %}--no-binary pycparser',
+        PIP_EXTRA_ARGS: '--no-binary pycparser',
         tags: ['atmosphere', 'pip-install-requirements'],
         when: INSTALL_DEV_REQUIREMENTS | default(False) }
 

--- a/playbooks/setup_troposphere.yml
+++ b/playbooks/setup_troposphere.yml
@@ -26,7 +26,7 @@
         REQUIREMENTS_FILE_NAME: 'requirements.txt',
         USE_PIP_TOOLS_SYNC: False,
         VIRTUAL_ENV: "{{ VIRTUAL_ENV_TROPOSPHERE | default(troposphere_virtualenv_path) }}",
-        PIP_EXTRA_ARGS: '{% if faster_dev_rebuild == false %}--no-cache-dir {% endif %}--no-binary pycparser',
+        PIP_EXTRA_ARGS: '--no-binary pycparser',
         tags: ['troposphere', 'pip-install-requirements'],
         when: not (INSTALL_DEV_REQUIREMENTS | default(False)) }
 
@@ -35,7 +35,7 @@
         REQUIREMENTS_FILE_NAME: 'dev_requirements.txt',
         USE_PIP_TOOLS_SYNC: False,
         VIRTUAL_ENV: "{{ VIRTUAL_ENV_TROPOSPHERE | default(troposphere_virtualenv_path) }}",
-        PIP_EXTRA_ARGS: '{% if faster_dev_rebuild == false %}--no-cache-dir {% endif %}--no-binary pycparser',
+        PIP_EXTRA_ARGS: '--no-binary pycparser',
         tags: ['troposphere', 'pip-install-requirements'],
         when: INSTALL_DEV_REQUIREMENTS | default(False) }
 

--- a/playbooks/setup_troposphere.yml
+++ b/playbooks/setup_troposphere.yml
@@ -28,7 +28,7 @@
         VIRTUAL_ENV: "{{ VIRTUAL_ENV_TROPOSPHERE | default(troposphere_virtualenv_path) }}",
         PIP_EXTRA_ARGS: '{% if faster_dev_rebuild == false %}--no-cache-dir {% endif %}--no-binary pycparser',
         tags: ['troposphere', 'pip-install-requirements'],
-        when: installation_type is not defined or installation_type != 'development' }
+        when: not (INSTALL_DEV_REQUIREMENTS | default(False)) }
 
     - { role: app-pip-install-requirements,
         APP_BASE_DIR: "{{ TROPOSPHERE_LOCATION | default(troposphere_directory_path) }}",
@@ -37,7 +37,7 @@
         VIRTUAL_ENV: "{{ VIRTUAL_ENV_TROPOSPHERE | default(troposphere_virtualenv_path) }}",
         PIP_EXTRA_ARGS: '{% if faster_dev_rebuild == false %}--no-cache-dir {% endif %}--no-binary pycparser',
         tags: ['troposphere', 'pip-install-requirements'],
-        when: installation_type is defined and installation_type == 'development' }
+        when: INSTALL_DEV_REQUIREMENTS | default(False) }
 
     - { role: app-config-logging,
         APP_BASE_DIR: "{{ TROPOSPHERE_LOCATION | default(troposphere_directory_path) }}",


### PR DESCRIPTION
This is part of the effort outlined to make clank more reasonable to configure. Don't have variables with misleading names, and don't have variables that set other vars. 

So rather than have `DEVELOPMENT: True` have narrow variables that are configured properly for in a development variables.yml. This makes configuration way easier to reason about.

This is part of https://pods.iplantcollaborative.org/jira/browse/ATMO-1993

TODO:

- [ ] Update changelog
- [x] Submit prs to variables repos, and link them below