### PR TITLE
Cleanup error throwing debug

### DIFF
--- a/roles/app-load-data-postgres/tasks/main.yml
+++ b/roles/app-load-data-postgres/tasks/main.yml
@@ -1,18 +1,7 @@
 ---
-# tasks file for app-load-data-postgres
-
-- debug: var=LOAD_DATABASE
-  when: DEBUG_OR_TEST_ROLE | default(False)
-
-- debug: var=DATABASE_FILE_TO_BE_LOADED
-  when: DEBUG_OR_TEST_ROLE | default(False)
-
 - name: copy over sql script for postgresql to run
   copy: src={{ DATABASE_FILE_TO_BE_LOADED }} dest={{ POSTGRES_SQL_INSTALL_DIRECTORY }}
   when: LOAD_DATABASE
-
-- debug: var={{ TARGET_SQL_LOAD_FILE }}
-  when: DEBUG_OR_TEST_ROLE | default(False)
 
 - name: run sql script for postgresql
   become: yes


### PR DESCRIPTION
The line including `var={{ ... }}` is not valid syntax. These debug statements
really shouldn't exist, just noise.

## Description

The line including `var={{ ... }}` is not valid syntax.
This fixes an error that is only triggered if you set `DEBUG_OR_TEST_ROLE: true`
## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated (README.md and dist_files/variables.yml.dist)
- [x] Reviewed and approved by at least one other contributor.
- [ ] Updated CHANGELOG.md
- [ ] New variables committed to secrets repos
