### PR TITLE
Let's Encrypt support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+- Add support for obtaining and deploying a TLS certificate from [Let's Encrypt](https://letsencrypt.org)
+  ([#224](https://github.com/cyverse/clank/pull/224))
+
 ## v2.1.0 (2017-09-??)
 
 - Change `INSTALLATION_TYPE` default from `development` to `production`

--- a/dist_files/variables.yml.dist
+++ b/dist_files/variables.yml.dist
@@ -46,10 +46,16 @@ INSTALLATION_TYPE: "production"  # can be development or production
 #ID_RSA: "{{ SECRETS_REPO }}/atmosphere_keypair_1"
 #ID_RSA_PUB: "{{ SECRETS_REPO }}/atmosphere_keypair_1.pub"
 
-# Define these if you are providing your own TLS (SSL) certificates, otherwise a self-signed certificate will be created for you
-# TLS_PRIVKEY_SRC_FILE: "{{ SECRETS_REPO }}/example.com.key"
-# TLS_CERT_SRC_FILE: "{{ SECRETS_REPO }}/example.com.crt"
-# TLS_CACHAIN_SRC_FILE: "{{ SECRETS_REPO }}/example.com.cachain.crt"
+# By default, a self-signed TLS certificate will be deployed. Uncomment and populate one of the following sections to provide your own certificate, or use Let's Encrypt to automatically obtain and deploy a certificate.
+
+# Bring Your Own Certificate
+# TLS_BYO_PRIVKEY_SRC: "{{ SECRETS_REPO }}/example.com.key"
+# TLS_BYO_CERT_SRC: "{{ SECRETS_REPO }}/example.com.crt"
+# TLS_BYO_CACHAIN_SRC: "{{ SECRETS_REPO }}/example.com.cachain.crt"
+
+# Let's Encrypt (will automatically obtain and deploy certificate)
+# TLS_LETSENCRYPT_ENABLE: true
+# TLS_LETSENCRYPT_EMAIL: "{{ ADMINS_EMAIL_TUPLE[0][1] }}"
 
 ###############################
 # 2. Authentication:
@@ -154,7 +160,7 @@ AUTH_MOCK_USER: "atmosphere_user"
 
 ###
 # THEME_IMAGES_PATH, expects an absolute path to an images directory
-# We recommend making a copy of the themeImagesDefault directory in Troposphere 
+# We recommend making a copy of the themeImagesDefault directory in Troposphere
 # <projectDir>/troposphere/static/theme/themeImagesDefault
 # Place it in an init directory and replace any image with a new image of equal size and name
 # Uncomment the variable below.

--- a/group_vars/atmosphere
+++ b/group_vars/atmosphere
@@ -42,8 +42,8 @@ ATMO:
         SITES_ENABLED_DIR: /etc/nginx/sites-enabled
         SERVER_URL: "{{ atmosphere_server_name }}"
         LEADERBOARD_URL:
-        NGINX_TLS_PRIVKEY_DEST: "{{ TLS_PRIVKEY_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.key"
-        NGINX_TLS_FULLCHAIN_DEST: "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt"
+        NGINX_TLS_PRIVKEY_DEST: "{{ TLS_PRIVKEY_PATH }}"
+        NGINX_TLS_FULLCHAIN_DEST: "{{ TLS_FULLCHAIN_PATH }}"
         VIRTUALENV_PATH: "{{ atmosphere_virtualenv_path }}"
 
     uwsgi.ini:
@@ -212,8 +212,8 @@ ATMO:
     celeryd.default:
         VIRTUALENV_PATH: "{{ atmosphere_virtualenv_path }}"
         ATMOSPHERE_LOCATION: "{{ ATMOSPHERE_LOCATION | default(atmosphere_directory_path) }}"
-        CELERYD_TLS_PRIVKEY_DEST: "{{ TLS_PRIVKEY_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.key"
-        CELERYD_TLS_CERT_DEST: "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt"
+        CELERYD_TLS_PRIVKEY_DEST: "{{ TLS_PRIVKEY_PATH }}"
+        CELERYD_TLS_CERT_DEST: "{{ TLS_FULLCHAIN_PATH }}"
         USE_PRODUCTION: "{{ celery_use_production }}"
         FLOWER_AUTH_SCHEME: "{{ FLOWER_AUTH_SCHEME | default('basic') }}"
         # Required if auth_scheme is 'basic'

--- a/group_vars/common
+++ b/group_vars/common
@@ -19,3 +19,4 @@ install_jenkins: "{{ DJANGO_JENKINS | default(False) }}"
 installation_type: "{{ INSTALLATION_TYPE | default('production') }}"
 faster_dev_rebuild: false
 shallow_clone: true
+TLS_LETSENCRYPT_TLS_SERVICE: "nginx"

--- a/group_vars/troposphere
+++ b/group_vars/troposphere
@@ -32,8 +32,8 @@ TROPO:
         TOKEN_EXPIRY_TIME_DAYS: 1
     theme:
         USE_THEME_IMAGES: "{{ THEME_IMAGES_PATH is defined }}"
-        PRIMARY_ONE_COLOR: "{{ PRIMARY_ONE_COLOR | default('')}}" 
-        PRIMARY_TWO_COLOR: "{{ PRIMARY_TWO_COLOR | default('')}}" 
+        PRIMARY_ONE_COLOR: "{{ PRIMARY_ONE_COLOR | default('')}}"
+        PRIMARY_TWO_COLOR: "{{ PRIMARY_TWO_COLOR | default('')}}"
         ACCENT_ONE_COLOR: "{{ ACCENT_ONE_COLOR | default('') }}"
         PICKER_HEADER_COLOR: "{{ PICKER_HEADER_COLOR | default('') }}"
         DANGER_COLOR: "{{ DANGER_COLOR | default('') }}"
@@ -51,8 +51,8 @@ TROPO:
         SITES_AVAILABLE_DIR: /etc/nginx/sites-available
         SITES_ENABLED_DIR: /etc/nginx/sites-enabled
         SERVER_URL: "{{ troposphere_server_name }}"
-        NGINX_TLS_PRIVKEY_DEST: "{{ TLS_PRIVKEY_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.key"
-        NGINX_TLS_FULLCHAIN_DEST: "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt"
+        NGINX_TLS_PRIVKEY_DEST: "{{ TLS_PRIVKEY_PATH }}"
+        NGINX_TLS_FULLCHAIN_DEST: "{{ TLS_FULLCHAIN_PATH }}"
         VIRTUALENV_PATH: "{{ VIRTUAL_ENV_TROPOSPHERE | default(troposphere_virtualenv_path) }}"
         ENABLE_WEBPACK_DEV_SERVER: "{{ ENABLE_WEBPACK_DEV_SERVER | default(False) }}"
 

--- a/playbooks/deploy_atmosphere.yml
+++ b/playbooks/deploy_atmosphere.yml
@@ -15,7 +15,7 @@
         tags: ['dependencies', 'database'] }
 
     - { role: tls-cert,
-        TLS_SUBJECT_ALTERNATE_NAME: "{{ atmosphere_server_name }}",
+        TLS_COMMON_NAME: "{{ atmosphere_server_name }}",
         tags: ['dependencies', 'ssl'] }
 
 - name: Clone Atmosphere Ansible

--- a/playbooks/deploy_troposphere.yml
+++ b/playbooks/deploy_troposphere.yml
@@ -15,7 +15,7 @@
         tags: ['dependencies', 'database'] }
 
     - { role: tls-cert,
-        TLS_SUBJECT_ALTERNATE_NAME: "{{ troposphere_server_name }}",
+        TLS_COMMON_NAME: "{{ troposphere_server_name }}",
         when: clean_target,
         tags: ['dependencies', 'ssl'] }
 

--- a/playbooks/utils/create_ca_and_cert_README.md
+++ b/playbooks/utils/create_ca_and_cert_README.md
@@ -20,9 +20,9 @@ After running that playbook you should see a bunch of new `*.pem` files.
 
 Add/update the following variables in your variables file:
 ```yaml
-TLS_PRIVKEY_SRC_FILE: "/path/to/*.server.key.pem"
-TLS_CERT_SRC_FILE:    "/path/to/*.server.cert.pem"
-TLS_CACHAIN_SRC_FILE: "/path/to/*.ca.cert.pem"
+TLS_BYO_PRIVKEY_SRC: "/path/to/*.server.key.pem"
+TLS_BYO_CERT_SRC:    "/path/to/*.server.cert.pem"
+TLS_BYO_CACHAIN_SRC: "/path/to/*.ca.cert.pem"
 ```
 
 At this point you should do a redeploy.

--- a/roles/tls-cert/.travis.yml
+++ b/roles/tls-cert/.travis.yml
@@ -22,8 +22,8 @@ env:
     version: 16.04
   - distribution: ubuntu
     version: 14.04
-  - distribution: ubuntu
-    version: 12.04
+#  - distribution: ubuntu
+#    version: 12.04
 
 before_install:
   - 'sudo docker run -it --name=test_dummy --privileged --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:rw cyverse/ansible-test:latest-${distribution}-${version} bash'

--- a/roles/tls-cert/README.md
+++ b/roles/tls-cert/README.md
@@ -1,82 +1,93 @@
-TLS Certificate
-=========
+# TLS Certificate
 
-Installs TLS (SSL) certificates to the target, in one of two ways depending on configuration:
+Installs TLS (SSL) certificates to the target, in one of three ways depending on configuration:
 - Installs your provided TLS certificate, private key, and CA certificate bundle to target system.
 - Deploys a new self-signed certificate + key to target system.
+- Obtains a TLS certificate from [Let's Encrypt](https://letsencrypt.org/) and configures automated certificate renewal via cron
 
 In either case, automatically creates a "full chain" file (containing certificate + CA bundle, suitable for use with Nginx) as well.
 
-Supports Ubuntu 12+ and CentOS 5+, adding support for other distros would be easy.
-
-Caveats / notices:
-On CentOS, file permissions for the private key are set to owner root and mode 600, because the enclosing `/etc/pki/tls/private` is permissively visible. (Compare to Ubuntu where the system-wide `/etc/ssl/private` directory already has restricted permissions.) Beyond that, this role does not do anything with file permissions, like configuring additional users/groups which can read the private key. That is left for the deployer to handle in a playbook. This role also does not configure other services that use the installed certificates.
+Supports Ubuntu LTS 14+ and CentOS 6+, adding support for other distros would be easy.
 
 [![Build Status](https://travis-ci.org/CyVerse-Ansible/ansible-tls-cert.svg?branch=master)](https://travis-ci.org/CyVerse-Ansible/ansible-tls-cert)
 [![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-tls--cert-blue.svg)](https://galaxy.ansible.com/CyVerse-Ansible/tls-cert/)
 
+## How to Use
+- If you want to create and deploy a self-signed certificate, don't define anything
+- If you want to Bring Your Own certificate, set the `TLS_BYO` vars (Ansible will look in "files" directory relative to playbook if you specify a bare filename or relative path.)
+- If you want to use Let's Encrypt, set the `TLS_LETSENCRYPT` vars
 
-Requirements
-------------
 
-If using this role to deploy a provided certificate then `openssl` must be available on the deployment host.
-If using this role to create and deploy a self-signed certificate then `openssl` must be available on the target host.
-(These are likely already true for any modern Linux system.)
+## Role Variables
 
-Role Variables
---------------
+| Variable                      | Required                     | Default             | Choices     | Comments                                                                    |
+|-------------------------------|------------------------------|---------------------|-------------|-----------------------------------------------------------------------------|
+| TLS_COMMON_NAME               | no                           | ansible_fqdn        |             | The fully qualified domain for the certficate                               |
+| TLS_BYO_PRIVKEY_SRC           | no                           |                     |             | Path to private key on deployer system                                      |
+| TLS_BYO_CERT_SRC              | no                           |                     |             | Path to certificate on deployer system                                      |
+| TLS_BYO_CACHAIN_SRC           | no                           |                     |             | Path to CA chain on deployer system                                         |
+| TLS_LETSENCRYPT_ENABLE        | no                           | false               | true, false | Obtain a certificate using Let's Encrypt                                    |
+| TLS_LETSENCRYPT_TLS_SERVICE   | no                           |                     |             | Name of service to stop when obtaining certificate and restart upon renewal |
+| TLS_LETSENCRYPT_EMAIL         | when TLS_LETSENCRYPT_ENABLE  |                     |             | Email address to associate with Let's Encrypt certificate                   |
 
-| Variable                            | Required         | Default                     | Choices             | Comments                                                   |
-|-------------------------------------|------------------|-----------------------------|---------------------|------------------------------------------------------------|
-| TLS_PRIVKEY_SRC_FILE                | no               |                             |                     | Path to private key on deployer system                     |
-| TLS_CERT_SRC_FILE                   | no               |                             |                     | Path to certificate on deployer system                     |
-| TLS_CACHAIN_SRC_FILE                | no               |                             |                     | Path to CA chain on deployer system                        |
-| TLS_DEST_BASENAME                   | no               | provided cert CN*           |                     | Base filename of installed certificate                     |
-| TLS_CREATE_SELFSIGNED               | no               | false                       | true, false         | Explicitly creates self-signed certificate                 |
-| TLS_CERT_DEST_DIR                   | no               | (distro-specific)           |                     | Directory for certificates on target host                  |
-| TLS_PRIVKEY_DEST_DIR                | no               | (distro-specific)           |                     | Directory for private keys on target host                  |
-| TLS_SUBJECT_ALTERNATE_NAME          | no               | ansible_fqdn                |                     | The fully qualified domain behind the generated certficate |
+These variables are registered by this role for use in your downstream automations:
 
-If you specify at least a TLS_PRIVKEY_SRC_FILE, TLS_CERT_SRC_FILE, and TLS_CACHAIN_SRC_FILE, then the provided files will be installed to the target. (Ansible will look in "files" directory relative to playbook if you specify a bare filename or relative path.) If these variables are not set by the deployer, then the role will create a self-signed certificate instead, with files selfsigned.crt and selfsigned.key. You can explicitly set `TLS_CREATE_SELFSIGNED: true` to override the default behavior and force creation of a self-signed certificate.
+| Variable           | Comments                      |
+|--------------------|-------------------------------|
+| TLS_PRIVKEY_PATH   | Path to private key on target |
+| TLS_CERT_PATH      | Path to certificate on target |
+| TLS_CACHAIN_PATH   | Path to CA chain on target    |
+| TLS_FULLCHAIN_PATH | Path to fullchain on target   |
 
-**`TLS_SUBJECT_ALTERNATE_NAME`** is the Subject Alternate Name (SAN) for the generated certificate. This field indicates the host behind the certificate. A valid example would be 'local.atmo.cloud'. The Chrome browser recently made this field mandatory. If you would like to learn about the history read this SO [answer](http://stackoverflow.com/a/14648100/1213041).
+**`TLS_COMMON_NAME`** is the Common Name (CN) for the generated certificate, and will also be used to set the Subject Alternate Name (SAN), which indicates the host behind the certificate. A valid example would be 'local.atmo.cloud'. The Chrome browser recently made this field mandatory. If you would like to learn about the history read this SO [answer](http://stackoverflow.com/a/14648100/1213041).
 
 `*` If the deployer provides a certificate, then the certificate's indicated CN (domain) will be used as the base name of the files on the target (e.g. `example.com.key`, `example.com.crt`, `example.com.cachain.crt`, and `example.com.fullchain.crt` for example.com). If this role creates a self-signed certificate, the files will be named with "selfsigned" as the base name. In either case, setting `TLS_DEST_BASENAME` overrides this filename.
 
-`**` By default, certificates and private keys are placed in the distro-specific system-wide default directories (but this can be overridden).
+## Caveats / Notices
+- `openssl` must be available on the _deployment host_ if using this role to deploy a provided certificate, and on the _target host_ if creating+deploying a self-signed certificate. These are likely already true for any modern Linux system.
 
-Dependencies
-------------
+- On CentOS, file permissions for the private key are set to owner root and mode 600, because the enclosing `/etc/pki/tls/private` is permissively visible. (Compare to Ubuntu where the system-wide `/etc/ssl/private` directory already has restricted permissions.) Beyond that, this role does not do anything with file permissions, like configuring additional users/groups which can read the private key. That is left for the deployer to handle in a playbook. This role also does not configure other services that use the installed certificates.
+
+- When deploying a certificate with Let's Encrypt, certbot will run in standalone mode. Port 443 must be made available for the standalone server to respond to the ACME challenge. You can provide the name of your service listening on port 443 with `TLS_LETSENCRYPT_TLS_SERVICE`, and this service will be temporarily stopped when obtaining/renewing the certificate.
+
+## Dependencies
 
 None
 
-Example Playbook
-----------------
-
-If you already have a certificate to install:
-
-    - hosts: all
-      roles:
-         - tls-cert
-      vars:
-         - TLS_PRIVKEY_SRC_FILE: example.com.key
-         - TLS_CERT_SRC_FILE: example.com.crt
-         - TLS_CACHAIN_SRC_FILE: example.com.cachain.crt
+## Example Playbook
 
 If you want to create a self-signed certificate, just call the role with no variables:
 
     - hosts: all
       roles:
-         - tls-cert
+        - tls-cert
 
-License
--------
+If you already have a certificate to install:
+
+    - hosts: all
+      roles:
+        - tls-cert
+      vars:
+        - TLS_BYO_PRIVKEY_SRC: 'example.com.key'
+        - TLS_BYO_CERT_SRC: 'example.com.crt'
+        - TLS_BYO_CACHAIN_SRC: 'example.com.cachain.crt'
+
+If you want to use Let's Encrypt (example Nginx web server):
+
+    - hosts: all
+      roles:
+        - tls-cert
+      vars:
+        - TLS_LETSENCRYPT_ENABLE: 'true'
+        - TLS_LETSENCRYPT_HTTPS_SERVICE: 'nginx'
+        - TLS_LETSENCRYPT_EMAIL: 'dont@spam.me'
+
+## License
 
 See license.md
 
-Author Information
-------------------
-
+## Author Information
 Chris Martin
+Connor Osborn
 
 https://cyverse.org

--- a/roles/tls-cert/defaults/main.yml
+++ b/roles/tls-cert/defaults/main.yml
@@ -1,3 +1,7 @@
 ---
 
 TLS_CREATE_SELFSIGNED: false
+TLS_COMMON_NAME: '{{ ansible_fqdn }}'
+TLS_DEST_BASENAME: '{{ TLS_COMMON_NAME }}'
+certbot_executable: 'certbot'
+le_obtain_cert: 'false'

--- a/roles/tls-cert/meta/.galaxy_install_info
+++ b/roles/tls-cert/meta/.galaxy_install_info
@@ -1,1 +1,1 @@
-{install_date: 'Thu Sep 14 15:57:18 2017', version: master}
+{install_date: 'Thu Sep 28 21:30:08 2017', version: master}

--- a/roles/tls-cert/meta/main.yml
+++ b/roles/tls-cert/meta/main.yml
@@ -29,8 +29,8 @@ galaxy_info:
   platforms:
   - name: EL
     versions:
-    - all
-    - 5
+    #- all
+    #- 5
     - 6
     - 7
   #- name: GenericUNIX
@@ -134,14 +134,14 @@ galaxy_info:
   #  - maverick
   #  - natty
   #  - oneiric
-    - precise
-    - quantal
-    - raring
-    - saucy
+    #- precise
+    #- quantal
+    #- raring
+    #- saucy
     - trusty
-    - utopic
-    - vivid
-    - wily
+    #- utopic
+    #- vivid
+    #- wily
     - xenial
   #- name: SLES
   #  versions:

--- a/roles/tls-cert/tasks/deploy-letsencrypt.yml
+++ b/roles/tls-cert/tasks/deploy-letsencrypt.yml
@@ -1,0 +1,130 @@
+---
+
+- name: File paths registered
+  set_fact:
+    TLS_PRIVKEY_PATH: '/etc/letsencrypt/live/{{ TLS_COMMON_NAME }}/privkey.pem'
+    TLS_CERT_PATH: '/etc/letsencrypt/live/{{ TLS_COMMON_NAME }}/cert.pem'
+    TLS_CACHAIN_PATH: '/etc/letsencrypt/live/{{ TLS_COMMON_NAME }}/chain.pem'
+    TLS_FULLCHAIN_PATH: '/etc/letsencrypt/live/{{ TLS_COMMON_NAME }}/fullchain.pem'
+
+- name: certbot installed on CentOS 6
+  get_url:
+    url: 'https://dl.eff.org/certbot-auto'
+    dest: '/opt/certbot-auto'
+    mode: 'a+x'
+  when: 'ansible_distribution == "CentOS" and ansible_distribution_major_version == "6"'
+
+- name: certbot executable set for CentOS 6
+  set_fact:
+    certbot_executable: '/opt/certbot-auto'
+  when: 'ansible_distribution == "CentOS" and ansible_distribution_major_version == "6"'
+
+- name: EPEL enabled for CentOS 7
+  yum:
+    name: 'epel-release'
+    state: 'installed'
+  when: 'ansible_distribution == "CentOS" and ansible_distribution_major_version == "7"'
+
+# Todo enable EPEL optional channel?
+
+- name: certbot installed for CentOS 7
+  yum:
+    name: 'certbot'
+    state: 'installed'
+  when: 'ansible_distribution == "CentOS" and ansible_distribution_major_version == "7"'
+
+- name: PPA dependency installed for Ubuntu
+  apt:
+    name: 'software-properties-common'
+    state: 'installed'
+  when: 'ansible_distribution == "Ubuntu"'
+
+- name: PPA dependency added for Ubuntu
+  apt_repository:
+    repo: 'ppa:certbot/certbot'
+    update_cache: true
+  when: 'ansible_distribution == "Ubuntu"'
+
+- name: certbot installed on Ubuntu
+  apt:
+    name: 'certbot'
+    state: 'latest'
+  when: 'ansible_distribution == "Ubuntu"'
+
+# To avoid hitting https://letsencrypt.org/docs/rate-limits
+# - Check to see if valid certificate already exists for requested domain
+# - Don't run certbot if a valid certificate already exists
+
+- name: Test if cert already exists
+  stat:
+    path: '{{ TLS_CERT_PATH }}'
+    follow: 'yes'
+  register: 'cert_stat'
+
+- name: Test if cert already exists
+  set_fact:
+    le_obtain_cert: true
+  when: 'cert_stat.stat.islnk is not defined'
+
+- name: TLS-using service stopped prior to obtaining certificate
+  service:
+    name: '{{ TLS_LETSENCRYPT_TLS_SERVICE }}'
+    state: 'stopped'
+  when: 'le_obtain_cert == true and TLS_LETSENCRYPT_TLS_SERVICE is defined'
+
+- name: Ensure nothing is listening on port 443
+  wait_for:
+    port: '443'
+    state: 'stopped'
+    timeout: '10'
+  when: 'le_obtain_cert == true'
+
+- name: Certificate obtained
+  command: >-
+    {{ certbot_executable }} certonly
+    --standalone
+    --keep-until-expiring
+    -n
+    --agree-tos
+    --email {{ TLS_LETSENCRYPT_EMAIL }}
+    --domain {{ TLS_COMMON_NAME }}
+  when: 'le_obtain_cert == true'
+
+- name: TLS-using service started after obtaining certificate
+  service:
+    name: '{{ TLS_LETSENCRYPT_TLS_SERVICE }}'
+    state: 'started'
+  when: 'le_obtain_cert == true and TLS_LETSENCRYPT_TLS_SERVICE is defined'
+
+- name: Renewal command set
+  set_fact:
+    renewal_command: >-
+      {{ certbot_executable }} renew
+      --pre-hook "service {{ TLS_LETSENCRYPT_TLS_SERVICE }} stop"
+      --post-hook "service {{ TLS_LETSENCRYPT_TLS_SERVICE }} start"
+      -n
+  when: 'TLS_LETSENCRYPT_TLS_SERVICE is defined'
+
+- name: Renewal command set
+  set_fact:
+    renewal_command: >-
+      {{ certbot_executable }} renew
+      -n
+  when: 'TLS_LETSENCRYPT_TLS_SERVICE is not defined'
+  tags:
+    - 'cron'
+
+- name: Renewal ran once
+  command: '{{ renewal_command }}'
+  changed_when: false
+
+- name: Renewal automated via cron
+  cron:
+    user: root
+    hour: '*/12'
+    minute: '{{ 59 |random(seed=inventory_hostname) }}'
+    job: '{{ renewal_command }} --quiet'
+    name: 'certbot-renew'
+    state: 'present'
+  tags:
+    - 'cron'

--- a/roles/tls-cert/tasks/deploy-provided.yml
+++ b/roles/tls-cert/tasks/deploy-provided.yml
@@ -1,49 +1,22 @@
 ---
 
 - include: get-cert-cn.yml
-  when: TLS_DEST_BASENAME is undefined
+  when: 'TLS_COMMON_NAME is undefined'
+
+- include: register-file-paths.yml
 
 - name: Certificate files copied to target
   tags: [certs-copied]
   copy:
-    src: "{{ item.src_path }}"
-    dest: "{{ item.dest_path }}"
+    src: '{{ item.src_path }}'
+    dest: '{{ item.dest_path }}'
   with_items:
-    - src_path: "{{ TLS_PRIVKEY_SRC_FILE }}"
-      dest_path: "{{ TLS_PRIVKEY_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.key"
-    - src_path: "{{ TLS_CERT_SRC_FILE }}"
-      dest_path: "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt"
-    - src_path: "{{ TLS_CACHAIN_SRC_FILE }}"
-      dest_path: "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt"
-
-# These series of tasks deserve an explanation.
-#
-# In the task: 'Full certificate chain created', we must concatenate several
-# files. However we should only concatenate the files when any of the input
-# files have changed. At this time, ansible does not have a mechanism for
-# this. Here we manually check the timestamps of the dependencies and the
-# output and if the dependencies are newer, then we recreate the output file.
-# a la make.
-
-- command: stat -c "%Y" "{{ TLS_PRIVKEY_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.key"
-  register: key_timestamp
-  changed_when: False
-- command: stat -c "%Y"  "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt"
-  register: crt_timestamp
-  changed_when: False
-- command: stat -c "%Y"  "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt"
-  register: cachain_timestamp
-  changed_when: False
-- command: stat -c "%Y"  "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt"
-  register: fullchain_timestamp
-  ignore_errors: yes # Intentionally fail, if the file doesn't exist
-  changed_when: False
+    - src_path: '{{ TLS_BYO_PRIVKEY_SRC }}'
+      dest_path: '{{ TLS_PRIVKEY_PATH }}'
+    - src_path: '{{ TLS_BYO_CERT_SRC }}'
+      dest_path: '{{ TLS_CERT_PATH }}'
+    - src_path: '{{ TLS_BYO_CACHAIN_SRC }}'
+      dest_path: '{{ TLS_CACHAIN_PATH }}'
 
 - name: Full certificate chain created
-  shell: >
-    cat {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt
-    {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt >>
-    {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt
-  when: fullchain_timestamp|failed or (key_timestamp.stdout|int()     > fullchain_timestamp.stdout|int())
-                                   or (crt_timestamp.stdout|int()     > fullchain_timestamp.stdout|int())
-                                   or (cachain_timestamp.stdout|int() > fullchain_timestamp.stdout|int())
+  shell: 'cat {{ TLS_CERT_PATH }} {{ TLS_CACHAIN_PATH }} > {{ TLS_FULLCHAIN_PATH }}'

--- a/roles/tls-cert/tasks/deploy-selfsigned.yml
+++ b/roles/tls-cert/tasks/deploy-selfsigned.yml
@@ -1,18 +1,20 @@
 ---
-- name: Create a directory to store temporary files
+- name: Directory created to store temporary files
   file:
-    path: "{{ role_path }}/build"
-    state: directory
+    path: '{{ role_path }}/build'
+    state: 'directory'
 
-- name: Generate ssl configuration file
+- name: openssl configuration file created
   template:
-    src: "{{ role_path }}/templates/openssl-req.cnf.j2"
-    dest: "{{ role_path }}/build/openssl-req.cnf"
+    src: '{{ role_path }}/templates/openssl-req.cnf.j2'
+    dest: '{{ role_path }}/build/openssl-req.cnf'
 
 - name: TLS_DEST_BASENAME set to "selfsigned" if not already overridden
   set_fact:
-    TLS_DEST_BASENAME: selfsigned
-  when: TLS_DEST_BASENAME is undefined
+    TLS_DEST_BASENAME: 'selfsigned'
+  when: 'TLS_DEST_BASENAME is undefined'
+
+- include: register-file-paths.yml
 
 - name: Self-signed certificate and private key created
   tags: [selfsigned-cert-created]
@@ -23,23 +25,23 @@
     -x509
     -nodes
     -days 3650
-    -keyout {{ TLS_PRIVKEY_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.key
-    -out {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt
+    -keyout {{ TLS_PRIVKEY_PATH }}
+    -out {{ TLS_CERT_PATH }}
   args:
-    creates: "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt"
+    creates: '{{ TLS_CERT_PATH }}'
 
 - name: Empty CA chain file created
   tags: [selfsigned-empty-bundle-created]
   file:
-    path: "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt"
-    state: touch
+    path: '{{ TLS_CACHAIN_PATH }}'
+    state: 'touch'
   # The following two lines work around https://github.com/ansible/ansible-modules-core/issues/170
-  register: touch_log
-  changed_when: touch_log.diff.before.state != "file"
+  register: 'touch_log'
+  changed_when: 'touch_log.diff.before.state != "file"'
 
 - name: Full certificate chain (same as bare self-signed certificate) created
   tags: [selfsigned-fullchain-created]
   copy:
-    src: "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt"
-    dest: "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt"
+    src: '{{ TLS_CERT_PATH }}'
+    dest: '{{ TLS_FULLCHAIN_PATH }}'
     remote_src: true

--- a/roles/tls-cert/tasks/get-cert-cn.yml
+++ b/roles/tls-cert/tasks/get-cert-cn.yml
@@ -5,11 +5,11 @@
 
 - name: Certificate copied to temporary location on target
   copy:
-    src: "{{ TLS_CERT_SRC_FILE }}"
+    src: "{{ TLS_BYO_CERT_SRC }}"
     dest: /tmp/ansible_tmp_cert
 
 - name: CN of provided certificate queried to determine TLS_DEST_BASENAME
-  # The following local_action may break if TLS_CERT_SRC_FILE is a relative path that is not resolveable from whichever working directory this is run
+  # The following local_action may break if TLS_BYO_CERT_SRC is a relative path that is not resolveable from whichever working directory this is run
   shell: openssl x509 -noout -subject -in /tmp/ansible_tmp_cert | sed -e 's/^subject.*CN=\([a-zA-Z0-9\.\-\*]*\).*$/\1/'
   register: CERT_CN
   changed_when: false

--- a/roles/tls-cert/tasks/main.yml
+++ b/roles/tls-cert/tasks/main.yml
@@ -1,37 +1,43 @@
 ---
 
 - name: Distro-specific variables gathered
-  include_vars: "{{ item }}"
+  include_vars: '{{ item }}'
   with_first_found:
-    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
-    - "{{ ansible_distribution }}.yml"
+    - '{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml'
+    - '{{ ansible_distribution }}.yml'
+
+- include: 'deploy-letsencrypt.yml'
+  when: TLS_LETSENCRYPT_ENABLE is defined
 
 - name: Ensure distro default cert paths exist
   tags: [ensure-distro-cert-paths]
   file:
-    path: "{{ item }}"
+    path: '{{ item }}'
     state: directory
   with_items:
-    - "{{ TLS_PRIVKEY_DEST_DIR }}"
-    - "{{ TLS_CERT_DEST_DIR }}"
+    - '{{ TLS_PRIVKEY_DEST_DIR }}'
+    - '{{ TLS_CERT_DEST_DIR }}'
+  when: TLS_LETSENCRYPT_ENABLE is not defined
 
 - include: deploy-provided.yml
   when: >
-      not TLS_CREATE_SELFSIGNED and
-      TLS_PRIVKEY_SRC_FILE is defined and
-      TLS_CERT_SRC_FILE is defined and
-      TLS_CACHAIN_SRC_FILE is defined
+      TLS_LETSENCRYPT_ENABLE is not defined and
+      TLS_BYO_PRIVKEY_SRC is defined and
+      TLS_BYO_CERT_SRC is defined and
+      TLS_BYO_CACHAIN_SRC is defined
 
 - include: deploy-selfsigned.yml
   when: >
-      TLS_CREATE_SELFSIGNED or
-      TLS_PRIVKEY_SRC_FILE is undefined or
-      TLS_CERT_SRC_FILE is undefined or
-      TLS_CACHAIN_SRC_FILE is undefined
+      TLS_LETSENCRYPT_ENABLE is not defined and
+      TLS_BYO_PRIVKEY_SRC is not defined and
+      TLS_BYO_CERT_SRC is not defined and
+      TLS_BYO_CACHAIN_SRC is not defined
 
 - name: Restricted file permissions set on private key
-  when: ansible_distribution == "CentOS"
+  when: >
+      TLS_LETSENCRYPT_ENABLE is not defined and
+      ansible_distribution == "CentOS"
   file:
-    path: "{{ TLS_PRIVKEY_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.key"
+    path: '{{ TLS_PRIVKEY_PATH }}'
     owner: root
     mode: 0600

--- a/roles/tls-cert/tasks/register-file-paths.yml
+++ b/roles/tls-cert/tasks/register-file-paths.yml
@@ -1,0 +1,6 @@
+- name: File paths registered
+  set_fact:
+    TLS_PRIVKEY_PATH: '{{ TLS_PRIVKEY_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.key'
+    TLS_CERT_PATH: '{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt'
+    TLS_CACHAIN_PATH: '{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt'
+    TLS_FULLCHAIN_PATH: '{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt'

--- a/roles/tls-cert/templates/openssl-req.cnf.j2
+++ b/roles/tls-cert/templates/openssl-req.cnf.j2
@@ -12,7 +12,7 @@ ST           = 'Arizona')
 L            = 'Tucson')
 O            = 'Organization Name')
 OU           = 'Organization Division')
-CN           = {{ TLS_SUBJECT_ALTERNATE_NAME | default(ansible_fqdn) }}
+CN           = {{ TLS_COMMON_NAME }}
 emailAddress = 'test@example.com'
 
 [ server_req_extensions ]
@@ -24,4 +24,4 @@ subjectAltName         = @alternate_names
 nsComment              = "OpenSSL Generated Certificate"
 
 [ alternate_names ]
-DNS.1 = {{ TLS_SUBJECT_ALTERNATE_NAME | default(ansible_fqdn) }}
+DNS.1 = {{ TLS_COMMON_NAME }}


### PR DESCRIPTION
![atmo-letsencrypt](https://user-images.githubusercontent.com/13605043/30990940-0b537992-a471-11e7-9d5a-824d89472391.png)

## Description
Integrated new [ansible-tls-cert](https://github.com/CyVerse-Ansible/ansible-tls-cert) into Clank. To deploy yourself an atmosphere(1) with a certificate from Let's Encrypt, simply set the following in your `variables.yml`:
```
TLS_LETSENCRYPT_ENABLE: true
TLS_LETSENCRYPT_EMAIL: "dont@spam.me"
```


## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature
  - [x] Deployed against a fresh instance using these options, confirmed that it works as expected:
    ```
    TLS_LETSENCRYPT_ENABLE: true
    TLS_LETSENCRYPT_EMAIL: "{{ ADMINS_EMAIL_TUPLE[0][1] }}"    
    ```
  - [x] Deployed with defaults (no options set), confirmed that it still generates and deploys a self-signed certificate
  - [x] Travis CI?
- [x] Documentation created/updated (README.md and dist_files/variables.yml.dist)
- [x] Reviewed and approved by at least one other contributor.
- [x] Updated CHANGELOG.md
- [x] New variables committed to environment-specific repos in companion PRs:
  - [x] [atmo-prod #23](https://gitlab.cyverse.org/atmosphere/atmo-prod/merge_requests/23)
  - [x] [atmo-beta #28](https://gitlab.cyverse.org/atmosphere/atmo-beta/merge_requests/28)
  - [x] [atmo-dev #19](https://gitlab.cyverse.org/atmosphere/atmo-dev/merge_requests/19)
  - [x] [atmo-local #45](https://gitlab.cyverse.org/atmosphere/atmo-local/merge_requests/45)