### PR TITLE
Install templated file against the target host

### DIFF
--- a/roles/app-install-instance-deploy-automation/tasks/main.yml
+++ b/roles/app-install-instance-deploy-automation/tasks/main.yml
@@ -3,9 +3,8 @@
 # Installation is *NOT* complete until the app-generate-ini role
 
 - name: If hosts file is missing, create hosts and move to ansible directory
-  local_action:
-    module: template
-    src: "{{ role_path }}/templates/hosts.j2"
+  template:
+    src: hosts.j2
     dest: "{{ INSTANCE_DEPLOY_AUTOMATION_DIR }}/ansible/hosts"
   when: INSTANCE_DEPLOY_AUTOMATION_HOSTS_FILE is undefined or INSTANCE_DEPLOY_AUTOMATION_HOSTS_FILE == ''
 


### PR DESCRIPTION
## Description
Problem: Clank was installing the templated file on the wrong machine
Solution: Install templated file onto the target host, not where ansible is being deployed from

Fixes: https://github.com/cyverse/clank/issues/223

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated (README.md and dist_files/variables.yml.dist)
- [x] Reviewed and approved by at least one other contributor.
- [ ] Updated CHANGELOG.md
- [ ] New variables committed to secrets repos
