### PR TITLE
Run instance-deploy celery worker as root user

### DIFF
--- a/roles/setup-celery/templates/celeryd.j2
+++ b/roles/setup-celery/templates/celeryd.j2
@@ -54,15 +54,14 @@ VIRTUALENV="{{ VIRTUAL_ENV_ATMOSPHERE }}"
 # Abs path to the 'celery' command
 CELERY_BIN="$VIRTUALENV/bin/celery"
 
-# Atmosphere Queues/Workers (unprivileged)
 {% if CELERYD_PRODUCTION_WORKER_SETUP %}
+# Atmosphere Queues/Workers (unprivileged)
 CELERYD_NODES="\
 atmosphere-node_1 atmosphere-node_2 atmosphere-node_3 atmosphere-node_4 \
 atmosphere-fast_1 atmosphere-fast_2 \
-atmosphere-deploy_1 atmosphere-deploy_2 atmosphere-deploy_3 atmosphere-deploy_4 \
-atmosphere-deploy_5 atmosphere-deploy_6 atmosphere-deploy_7 \
 celery_periodic \
-email"
+email \
+"
 CELERYD_WORKER_OPTS="\
 -Q:atmosphere-node_1 default -c:atmosphere-node_1 5 -O:atmosphere-node_1 fair \
 -Q:atmosphere-node_2 default -c:atmosphere-node_2 5 -O:atmosphere-node_2 fair \
@@ -70,6 +69,19 @@ CELERYD_WORKER_OPTS="\
 -Q:atmosphere-node_4 default -c:atmosphere-node_4 5 -O:atmosphere-node_4 fair \
 -Q:atmosphere-fast_1 fast_deploy -c:atmosphere-fast_1 5 -O:atmosphere-fast_1 fair \
 -Q:atmosphere-fast_2 fast_deploy -c:atmosphere-fast_2 5 -O:atmosphere-fast_2 fair \
+-Q:email email -c:email 3  -O:email fair \
+-Q:celery_periodic periodic -c:celery_periodic 3 -O:celery_periodic fair \
+-Q:email email -c:email 1 -O:email fair \
+"
+
+# Atmosphere Queues/Workers (privileged)
+CELERYD_PRIVILEGED_NODES="\
+imaging \
+atmosphere-deploy_1 atmosphere-deploy_2 atmosphere-deploy_3 atmosphere-deploy_4 \
+atmosphere-deploy_5 atmosphere-deploy_6 atmosphere-deploy_7 \
+"
+CELERYD_PRIVILEGED_WORKER_OPTS="\
+-Q:imaging imaging -c:imaging 1 -O:imaging fair \
 -Q:atmosphere-deploy_1 ssh_deploy -c:atmosphere-deploy_1 2 -O:atmosphere-deploy_1 fair \
 -Q:atmosphere-deploy_2 ssh_deploy -c:atmosphere-deploy_2 2 -O:atmosphere-deploy_2 fair \
 -Q:atmosphere-deploy_3 ssh_deploy -c:atmosphere-deploy_3 2 -O:atmosphere-deploy_3 fair \
@@ -77,19 +89,24 @@ CELERYD_WORKER_OPTS="\
 -Q:atmosphere-deploy_5 ssh_deploy -c:atmosphere-deploy_5 2 -O:atmosphere-deploy_5 fair \
 -Q:atmosphere-deploy_6 ssh_deploy -c:atmosphere-deploy_6 2 -O:atmosphere-deploy_6 fair \
 -Q:atmosphere-deploy_7 ssh_deploy -c:atmosphere-deploy_7 2 -O:atmosphere-deploy_7 fair \
--Q:email email -c:email 3  -O:email fair \
--Q:celery_periodic periodic -c:celery_periodic 3 -O:celery_periodic fair \
--Q:email email -c:email 1 -O:email fair"
+"
 {% else %}
-CELERYD_NODES="atmosphere-node_1 atmosphere-deploy_1"
+# Atmosphere Queues/Workers (unprivileged)
+CELERYD_NODES="atmosphere-node"
 CELERYD_WORKER_OPTS="\
--Q:atmosphere-node_1 default,email,celery_periodic -c:atmosphere-node_1 13 -O:atmosphere-node_1 fair \
--Q:atmosphere-deploy_1 fast_deploy,ssh_deploy -c:atmosphere-deploy_1 10 -O:atmosphere-deploy_1 fair"
-{% endif %}
+-Q:atmosphere-node default,email,celery_periodic,fast-deploy -c:atmosphere-node 13 -O:atmosphere-node fair \
+"
 
 # Atmosphere Queues/Workers (privileged)
-CELERYD_PRIVILEGED_NODES="imaging"
-CELERYD_PRIVILEGED_WORKER_OPTS="-Q:imaging imaging -c:imaging 1 -O:imaging fair"
+CELERYD_PRIVILEGED_NODES="\
+imaging \
+atmosphere-deploy \
+"
+CELERYD_PRIVILEGED_WORKER_OPTS="\
+-Q:imaging imaging -c:imaging 1 -O:imaging fair \
+-Q:atmosphere-deploy ssh_deploy -c:atmosphere-deploy 10 -O:atmosphere-deploy fair \
+"
+{% endif %}
 
 CELERYD_OPTS="\
 --app=$CELERY_APP


### PR DESCRIPTION
## Description

Previoulsy we were deploying against vms with the www-data user. There are several hitches required to make this work. We would need www-data have permissions on ssh keys and make sure that that user has an ssh config in their home directory, and make sure that they have a home directory with the right permissions.

It's not really obvious that there is any benefit to running ansible deploys as non-root. Its less secure since every web request would be running with permissions enabling them to ssh into vms.

This change makes ansible deploys left to a root worker. I tested and verified that all tasks which use ssh are in the proper queue `ssh_deploy`.

Include snippets of code to help reviewers test your code!

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated (README.md and dist_files/variables.yml.dist)
- [ ] Reviewed and approved by at least one other contributor.
- [ ] Updated CHANGELOG.md
- [ ] New variables committed to secrets repos
