### PR TITLE
Document variable to toggle the number of workers in celery

### DIFF
--- a/dist_files/variables.yml.dist
+++ b/dist_files/variables.yml.dist
@@ -307,3 +307,6 @@ AUTH_MOCK_USER: "atmosphere_user"
 # faster_dev_rebuild: true
 #Uncomment so that virtualenvs stick around after multiple deploys (much faster build time, sometimes causes pip package issues)
 # REINSTALL_VENV: false
+
+# Uncomment so celeryd consumes less resources (fewer workers and processes)
+# CELERYD_PRODUCTION_WORKER_SETUP: false


### PR DESCRIPTION
## Description

Document a variable that can be used to make the celery init script more friendly for development environments.

This variable has a production default so only atmo-local vars need an update.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [x] Documentation created/updated (README.md and dist_files/variables.yml.dist)
- [ ] Reviewed and approved by at least one other contributor.
- [ ] Updated CHANGELOG.md
- [ ] New variables committed to secrets repos
