### PR TITLE
Fix parse error for celeryd init script

### DIFF
--- a/roles/setup-celery/templates/celeryd.j2
+++ b/roles/setup-celery/templates/celeryd.j2
@@ -94,7 +94,7 @@ CELERYD_PRIVILEGED_WORKER_OPTS="\
 # Atmosphere Queues/Workers (unprivileged)
 CELERYD_NODES="atmosphere-node"
 CELERYD_WORKER_OPTS="\
--Q:atmosphere-node default,email,celery_periodic,fast-deploy -c:atmosphere-node 13 -O:atmosphere-node fair \
+-Q default,email,celery_periodic,fast-deploy -c 13 -O fair \
 "
 
 # Atmosphere Queues/Workers (privileged)


### PR DESCRIPTION
Problem: service celeryd start throws exception when CELERYD_PRODUCTION_WORKER_SETUP=false
Solution: call celery cli differently

The celeryd cli does not support indexing by worker name, when there is only
one worker so "-c:workername-with-hyphen 3"  would result in:
```
ValueError: invalid literal for int() with base 10: 'workername'
```
Seems like a celeryd bug, multi should support 1 or more workers..

## Description

Please describe your pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue. When linking to an issue, please use
`refs #...` in the description of the pull request.

Include snippets of code to help reviewers test your code!

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated (README.md and dist_files/variables.yml.dist)
- [ ] Reviewed and approved by at least one other contributor.
- [ ] Updated CHANGELOG.md
- [ ] New variables committed to secrets repos
