### PR TITLE
Fix travis crypto dep error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,14 @@
     - sudo pg_dropcluster --stop 9.4 main
     - sudo pg_dropcluster --stop 9.5 main
     - sudo pg_lsclusters # For testing purposes
-
-  before_script:
     - virtualenv clank_env
     - . clank_env/bin/activate
+
+  install:
+    - pip install -U pip setuptools
     - pip install -r requirements.txt
+
+  before_script:
     - cp dist_files/variables.yml.dist variables.yml
 
   script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
 ansible==2.3.0.0
-# This can be removed if and when https://github.com/ansible/ansible/pull/16723 gets resolved
-setuptools>=11.3


### PR DESCRIPTION
## Description

Problem: out of date setuptools causes travis build failure
Solution: install latest setuptools by installing after virtualenv is created

**Note:** travis is still broken, but it's failing because of a separate issue with postgres see (https://github.com/cyverse/clank/pull/239)
## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated (README.md and dist_files/variables.yml.dist)
- [ ] Reviewed and approved by at least one other contributor.
- [ ] Updated CHANGELOG.md
- [ ] New variables committed to secrets repos
