### PR TITLE
Postgres 10

### DIFF
--- a/group_vars/common
+++ b/group_vars/common
@@ -5,7 +5,7 @@ workspace: "{{WORKSPACE | default('/opt/dev')}}"
 secrets_repo: "{{ SECRETS_REPO | default('/opt/dev/clank_workspace/atmo-extras')}}"
 virtualenv_dir: "{{VIRTUAL_ENV_DIR | default('/opt/env')}}"
 github_branch: master
-db_version: 9.6
+pg_version: 9.6
 server_name: "{{ SERVER_NAME | default(ansible_fqdn) }}"
 nginx_combined_cert_dir: "/etc/ssl/certs"
 nginx_combined_cert_file: "combined_atmo_ssl_cert.pem"

--- a/playbooks/deploy_atmosphere.yml
+++ b/playbooks/deploy_atmosphere.yml
@@ -10,8 +10,9 @@
         tags: ['dependencies', 'apt-install', 'install'] }
 
     - { role: setup-postgres,
+        DB_USER: "{{ ATMO_DBUSER | default(atmosphere_database_user) }}",
+        DB_VERSION: "{{ pg_version }}",
         when: clean_target,
-        DBUSER: "{{ ATMO_DBUSER | default(atmosphere_database_user) }}",
         tags: ['dependencies', 'database'] }
 
     - { role: tls-cert,

--- a/playbooks/deploy_troposphere.yml
+++ b/playbooks/deploy_troposphere.yml
@@ -10,8 +10,9 @@
         tags: ['dependencies', 'apt-install', 'install'] }
 
     - { role: setup-postgres,
+        DB_USER: "{{ TROPO_DBUSER | default(troposphere_database_user) }}",
+        DB_VERSION: "{{ pg_version }}",
         when: clean_target,
-        DBUSER: "{{ TROPO_DBUSER | default(troposphere_database_user) }}",
         tags: ['dependencies', 'database'] }
 
     - { role: tls-cert,

--- a/playbooks/setup_atmosphere.yml
+++ b/playbooks/setup_atmosphere.yml
@@ -18,7 +18,7 @@
         LOAD_DATABASE: "ATMO_DATA.LOAD_DATABASE | default(False)",
         DATABASE_FILE_TO_BE_LOADED: "{{ ATMO_DATA.SQL_DUMP_FILE }}",
         when: ATMO_DATA is defined and ATMO_DATA.SQL_DUMP_FILE is defined and ATMO_DATA.LOAD_DATABASE is defined,
-        tags: ['atmosphere', 'data-load'] }
+        tags: ['atmosphere', 'database', 'data-load'] }
 
     - { role: delete-files,
         LOCATION: "{{ ATMOSPHERE_LOCATION | default(atmosphere_directory_path) }}",

--- a/playbooks/setup_troposphere.yml
+++ b/playbooks/setup_troposphere.yml
@@ -14,7 +14,7 @@
         LOAD_DATABASE: "{{ TROPO_DATA.LOAD_DATABASE }}",
         DATABASE_FILE_TO_BE_LOADED: "{{ TROPO_DATA.SQL_DUMP_FILE }}",
         when: TROPO_DATA is defined and TROPO_DATA.SQL_DUMP_FILE is defined and TROPO_DATA.LOAD_DATABASE,
-        tags: ['troposphere', 'data-load'] }
+        tags: ['troposphere', 'database', 'data-load'] }
 
     - { role: delete-files,
         LOCATION: "{{ TROPOSPHERE_LOCATION | default(troposphere_directory_path) }}",

--- a/roles/app-config-postgres/tasks/main.yml
+++ b/roles/app-config-postgres/tasks/main.yml
@@ -33,7 +33,7 @@
 - name: ensure user has access to {{ DBNAME | default("") }} database
   become: yes
   become_user: postgres
-  postgresql_user: db={{ DBNAME }} name={{ DBUSER }} password={{ DBPASSWORD }} priv=ALL
+  postgresql_user: encrypted=yes db={{ DBNAME }} name={{ DBUSER }} password={{ DBPASSWORD }} priv=ALL
 
 - name: add {{ DBUSER | default("") }} user connect privileges
   become: yes

--- a/roles/app-config-postgres/tasks/main.yml
+++ b/roles/app-config-postgres/tasks/main.yml
@@ -14,6 +14,7 @@
   service:
     name: postgresql
     state: restarted
+    args: "{{ pg_version | default('9.6') }}"
   when: LOAD_DATABASE
 
 - name: Drop any existing database if loading from a dump file

--- a/roles/install-dependencies/vars/Ubuntu.yml
+++ b/roles/install-dependencies/vars/Ubuntu.yml
@@ -4,7 +4,7 @@ APT_REPOSITORIES_TO_REMOVE:
 APT_REPOSITORIES_TO_ADD:
   - ppa:nginx/stable
   - deb https://deb.nodesource.com/node_8.x {{ ansible_distribution_release }} main
-  - deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main {{ db_version | default('9.6') }}
+  - deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main {{ pg_version | default('9.6') }}
   - ppa:chris-lea/redis-server
 
 APT_KEYS_TO_ADD:
@@ -143,7 +143,7 @@ DEV_PACKAGES:
   - g++
   - make
   - build-essential
-  - postgresql-{{ db_version | default('9.6') }}
+  - postgresql-{{ pg_version | default('9.6') }}
   - postgresql-contrib
   - python-psycopg2
   - postgresql-server-dev-all

--- a/roles/install-dependencies/vars/Ubuntu.yml
+++ b/roles/install-dependencies/vars/Ubuntu.yml
@@ -144,9 +144,9 @@ DEV_PACKAGES:
   - make
   - build-essential
   - postgresql-{{ pg_version | default('9.6') }}
-  - postgresql-contrib
+  - postgresql-contrib-{{ pg_version | default('9.6') }}
+  - postgresql-server-dev-{{ pg_version | default('9.6') }}
   - python-psycopg2
-  - postgresql-server-dev-all
   - libpq-dev
   - python-dev
   - libldap2-dev

--- a/roles/setup-postgres/README.md
+++ b/roles/setup-postgres/README.md
@@ -1,15 +1,19 @@
 setup-postgres
 ==================
 
-Configure pg_hba.conf & and ensure postgres is running 
+Configure postgres for a user and port and ensure that only this postgres
+version is running
 
 Requirements
 ------------
 
-Role Variables
---------------
+## Role Variables
 
-- `DBUSER` - user which needs access to the database 
+| Variable     | Required   | Default    | Choices   | Comments                           |
+|--------------|------------|------------|-----------|------------------------------------|
+| DB_USER      | no         | postgres   |           | User that is granted password auth |
+| DB_VERSION   | no         | 9.6        |           | Postgres version                   |
+| DB_PORT      | no         | 5432       |           | Database port                      |
 
 Dependencies
 ------------
@@ -20,13 +24,5 @@ Example Playbook
 ```
     - hosts: all
       roles:
-        - { role: setup-postgres,
-            when: clean_target,
-            DBUSER: "{{ TROPO_DBUSER }}",
-            tags: ['dependencies', 'database'] }
+        - { role: setup-postgres }
 ```
-
-License
--------
-
-BSD

--- a/roles/setup-postgres/defaults/main.yml
+++ b/roles/setup-postgres/defaults/main.yml
@@ -1,2 +1,3 @@
 POSTGRES_SQL_INSTALL_DIRECTORY: /var/lib/postgresql
 DB_VERSION: "{{ pg_version | default('9.6') }}"
+DB_PORT: 5432

--- a/roles/setup-postgres/defaults/main.yml
+++ b/roles/setup-postgres/defaults/main.yml
@@ -1,3 +1,3 @@
-POSTGRES_SQL_INSTALL_DIRECTORY: /var/lib/postgresql
-DB_VERSION: "{{ pg_version | default('9.6') }}"
+DB_VERSION: 9.6
 DB_PORT: 5432
+DB_USER: postgres

--- a/roles/setup-postgres/defaults/main.yml
+++ b/roles/setup-postgres/defaults/main.yml
@@ -1,2 +1,2 @@
 POSTGRES_SQL_INSTALL_DIRECTORY: /var/lib/postgresql
-DB_VERSION: "{{ db_version | default('9.6') }}"
+DB_VERSION: "{{ pg_version | default('9.6') }}"

--- a/roles/setup-postgres/handlers/main.yml
+++ b/roles/setup-postgres/handlers/main.yml
@@ -1,2 +1,0 @@
-- name: restart postgresql
-  service: name=postgresql state=started args={{ DB_VERSION }}

--- a/roles/setup-postgres/tasks/main.yml
+++ b/roles/setup-postgres/tasks/main.yml
@@ -1,3 +1,9 @@
+- name: Configure postgres to run on port {{ DB_PORT }}
+  lineinfile:
+    regexp: "^port = \\d+"
+    dest: "/etc/postgresql/{{ DB_VERSION }}/main/postgresql.conf"
+    line: "port = {{ DB_PORT }}"
+
 # We must remove the line that we want to insert, otherwise ansible will not
 # respect "insertbefore". It's only respected when inserting lines that don't
 # already exist, so if you want to insert a line, you must remove it first.
@@ -23,7 +29,11 @@
   tags:
     - postgres
 
-- name: Restart postgres to reload configuration
-  service: name=postgresql state=restarted args={{ DB_VERSION }}
-  tags:
-    - postgres
+# Note: the postgresql service script doesn't reliably stop the service, by
+# providing 'pattern=postgres' ansible verfies the process is stopped by looking in the
+# process table
+- name: Stop all existing postgres services
+  service: name=postgresql state=stopped pattern='postgresql'
+
+- name: Starting postgres {{ DB_VERSION }}
+  service: name=postgresql state=started args={{ DB_VERSION }}

--- a/roles/setup-postgres/tasks/main.yml
+++ b/roles/setup-postgres/tasks/main.yml
@@ -14,20 +14,17 @@
     - name: "Explicitly remove database user, to ensure inserting in the right location"
       lineinfile:
           dest: "/etc/postgresql/{{ DB_VERSION }}/main/pg_hba.conf"
-          regexp: "^local +all +{{ DBUSER }} +md5"
+          regexp: "^local +all +{{ DB_USER }} +md5"
           state: absent
 
-    - name: "Give database user ({{ DBUSER }}) password authentication on domain sockets"
+    - name: "Give database user ({{ DB_USER }}) password authentication on domain sockets"
       lineinfile:
         dest: "/etc/postgresql/{{ DB_VERSION }}/main/pg_hba.conf"
 
         # Note: We must insert 'line' before this more restrictive line, if it exists.
         insertbefore: "^local +all +all +peer"
 
-        line: "local   all              {{ DBUSER }}                  md5"
-
-  tags:
-    - postgres
+        line: "local   all              {{ DB_USER }}                  md5"
 
 # Note: the postgresql service script doesn't reliably stop the service, by
 # providing 'pattern=postgres' ansible verfies the process is stopped by looking in the


### PR DESCRIPTION
## Description

This pr depends on #238, which should be merged first.

This pr allows clank to install either postgres 9.6 or 10. The default is 9.6.
```
# Setup postgres 10
ansible-playbook -e @$ENV_FILE playbooks/deploy_stack.yml  -e pg_version=10 --tags database

# Setup postgres 9.6
ansible-playbook -e @$ENV_FILE playbooks/deploy_stack.yml  -e pg_version=9.6 --tags database
```
The above commands don't ensure that anything is loaded into the db, so if you're going from 9.6 -> 10, you should do an entire clank run with:
```
ATMO_DATA:
  LOAD_DATABASE: True
  SQL_DUMP_FILE: /path/to/sql/dump
```

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated (README.md and dist_files/variables.yml.dist)
- [ ] Reviewed and approved by at least one other contributor.
- [ ] Updated CHANGELOG.md
- [ ] New variables committed to secrets repos
