### PR TITLE
Fix travis err during npm install

### DIFF
--- a/roles/build-install-troposphere-ui-assets/tasks/main.yml
+++ b/roles/build-install-troposphere-ui-assets/tasks/main.yml
@@ -1,45 +1,22 @@
 ---
-# tasks file for build-install-troposphere-ui-assets
-
-- name: remove node modules
+- name: Remove node modules
   file: path={{ NPM_APP_DIR }}/node_modules state=absent
   when: NPM_CLEAN_BUILD
 
-- name: disable npm progress bar for speed boost
-  shell: npm set progress=false
-  register: result
-  
-- debug: var=result.stdout_lines
-  when: CLANK_VERBOSE | default(False)
-
 - name: run npm install
-  action: shell npm install
-  args:
-    chdir: "{{ NPM_APP_DIR }}"
-  register: first_run
-  failed_when: false
-
-- name: remove node modules after failed first attempt
-  file: path={{ NPM_APP_DIR }}/node_modules state=absent
-  when: first_run.rc != 0
-
-- name: run npm install after failed first attempt
-  action: shell npm install
+  command: npm install
   args:
     chdir: "{{ NPM_APP_DIR }}"
   register: result
-  until: result.rc == 0
-  retries: 2
-  when: first_run.rc != 0 
 
-- debug: var=result.stdout_lines
-  when: CLANK_VERBOSE | default(False)
+- name: Log output of npm install
+  debug: var=result.stdout_lines
 
-- name: run npm build
+- name: Run npm build
+  command: npm run build --{{ NPM_BUILD_TYPE | default("production")}}
   args:
     chdir: "{{ NPM_APP_DIR }}"
-  shell: npm run build --{{ NPM_BUILD_TYPE | default("production")}}
-  register: output
+  register: result
 
-- debug: var=output.stdout_lines
-  when: CLANK_VERBOSE | default(False)
+- name: Log output of npm build
+  debug: var=result.stdout_lines

--- a/roles/build-install-troposphere-ui-assets/tasks/main.yml
+++ b/roles/build-install-troposphere-ui-assets/tasks/main.yml
@@ -4,7 +4,7 @@
   when: NPM_CLEAN_BUILD
 
 - name: run npm install
-  command: npm install
+  command: npm install --unsafe-perm
   args:
     chdir: "{{ NPM_APP_DIR }}"
   register: result


### PR DESCRIPTION
## Description
**Note:** this depends on #239, which should be merged first

Problem: travis times out during npm install (see this [build](https://travis-ci.org/cyverse/clank/builds/301580614#L2780-L2791))
Solution: during a root npm install, explicitly allow pkgs' build scripts to build as root by using (--unsafe-perm), this fixed an issue where node-gyp had the wrong permissions and tried indefinitely

When you npm install as root, npm tries to protect you and runs build scripts as a non-privileged user (otherwise you're allowing any npm package root access on your machine). This almost always fails, because the source code is typically owned by the root user, so this unprivileged build will fail.


## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated (README.md and dist_files/variables.yml.dist)
- [ ] Reviewed and approved by at least one other contributor.
- [ ] Updated CHANGELOG.md
- [ ] New variables committed to secrets repos
