### PR TITLE
Problem: atmosphere startup script is not idempotent

### DIFF
--- a/roles/atmosphere-include-startup/files/atmosphere
+++ b/roles/atmosphere-include-startup/files/atmosphere
@@ -34,13 +34,12 @@ case "$1" in
             echo service "$name" "$1";
 
             # Perform action
-            service "$name" "$1" &>/dev/null;
+            service "$name" "$1"
 
             # Fail/exit if action fails
             if [ $? -ne 0 ]; then
-                echo "Exiting: service $name $1 failed" 2>&1;
+                echo "Warning: service $name $1 failed" 2>&1;
                 echo "rerun that command, to see specific errors" 2>&1;
-                exit 1;
             fi
         done
         ;;


### PR DESCRIPTION
## Description
Services like celery and celerybeat will throw an exit code of 1 if they have already been started/stopped.
Atmosphere service previously bailed out on non-zero exit codes.

### Solution
Instead, show the output of the individual calls being made, and print a warning (but continue to other services)
if a non-zero exit code is found.

## Checklist before merging Pull Requests
- [ ] Reviewed and approved by at least one other contributor.
