### PR TITLE
Instance access companion PR

### DIFF
--- a/group_vars/atmosphere
+++ b/group_vars/atmosphere
@@ -136,6 +136,7 @@ ATMO:
         TIME_ZONE: "{{ TIME_ZONE | default('') }}"
         ORG_NAME: "{{ ORG_NAME | default('') }}"
         AUTO_CREATE_NEW_ACCOUNTS: True
+        AUTO_APPROVE_INSTANCE_ACCESS: "{{ AUTO_APPROVE_INSTANCE_ACCESS | default(False) }}"
         AUTO_CREATE_NEW_PROJECTS: "{{ AUTO_CREATE_NEW_PROJECTS | default(False) }}"
         ALLOCATION_SOURCE_COMPUTE_ALLOWED: "{{ ALLOCATION_SOURCE_COMPUTE_ALLOWED | default('') }}"
         ACCOUNT_CREATION_PLUGINS: "{{ ACCOUNT_CREATION_PLUGINS | default(['atmosphere.plugins.accounts.creation.UserGroup']) }}"


### PR DESCRIPTION
Include new instance access group_vars for 'atmosphere:local.py'

Required to use: https://github.com/cyverse/atmosphere/pull/446