### PR TITLE
Fix incorrect queue names

### DIFF
--- a/roles/setup-celery/templates/celeryd.j2
+++ b/roles/setup-celery/templates/celeryd.j2
@@ -94,7 +94,7 @@ CELERYD_PRIVILEGED_WORKER_OPTS="\
 # Atmosphere Queues/Workers (unprivileged)
 CELERYD_NODES="atmosphere-node"
 CELERYD_WORKER_OPTS="\
--Q default,email,celery_periodic,fast-deploy -c 13 -O fair \
+-Q default,email,periodic,fast_deploy -c 13 -O fair \
 "
 
 # Atmosphere Queues/Workers (privileged)


### PR DESCRIPTION

## Description

#### Problem:
when `CELERYD_PRODUCTION_WORKER_SETUP : false`, instance launch wouldn't work

#### Solution:
fix the celeryd configuration, so that tasks get routed to correct queues

celery_periodic and fast-deploy were typos in the queue names, so tasks were being put in queues that had no workers working through them

only affects dev environments

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated (README.md and dist_files/variables.yml.dist)
- [ ] Reviewed and approved by at least one other contributor.
- [ ] Updated CHANGELOG.md
- [ ] New variables committed to secrets repos
