### PR TITLE
Make clone-repo more verbose

### DIFF
--- a/roles/clone-repo/tasks/main.yml
+++ b/roles/clone-repo/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: clone git repo with branched defined 
+- name: "Clone git repo {{ REPO_URI }} with branch {{ branch }}"
   git:
     repo: "{{ REPO_URI }}"
     dest: "{{ CLONE_TARGET }}"
@@ -6,4 +6,6 @@
     clone: yes
     depth: "{%- if shallow_clone -%}1{%- else -%}0{%- endif -%}"
     update: yes
-    version: "{{ SPECIFIC_BRANCH | default('master', true) }}"
+    version: "{{ branch }}"
+  vars:
+    branch: "{{ SPECIFIC_BRANCH | default('master', true) }}"


### PR DESCRIPTION
## Description
#### Problem:
    When there are local modifications clone-repo fails, and doesn't mention where they are
```
    TASK [clone-repo : clone git repo with branched defined]
    ...
    fatal: "Local modifications exist in repository (force=no)
```
#### Solution:
```
    TASK [clone-repo : Clone git repo https://github.com/CyVerse/atmosphere-ansible.git with branch master]
    ...
    fatal: "Local modifications exist in repository (force=no)
```
To test:
```
# Make a modification to tropo readme
echo hi >> /opt/dev/troposphere/README.md
# Try to use clone-repo with troposphere
ansible-playbook -e @$ENV_FILE playbooks/deploy_troposphere.yml --tags clone-repo
```
## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated (README.md and dist_files/variables.yml.dist)
- [x] Reviewed and approved by at least one other contributor.
- [ ] Updated CHANGELOG.md
- [ ] New variables committed to secrets repos
