### PR TITLE
Fix celerybeat failing to stop process

### DIFF
--- a/roles/setup-celery/templates/celerybeat.j2
+++ b/roles/setup-celery/templates/celerybeat.j2
@@ -125,7 +125,7 @@ stop() {
     fi;
 
     # Force shutdown
-    kill -KILL $process;
+    kill -KILL "$pid";
     echo "$SCRIPT_NAME was forcefully stopped" >&2;
 }
 


### PR DESCRIPTION
## Description

#### Problem:
Script restart would not actually stop the service

#### Solution:
Actually pass the $pid to kill

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated (README.md and dist_files/variables.yml.dist)
- [x] Reviewed and approved by at least one other contributor.
- [ ] Updated CHANGELOG.md
- [ ] New variables committed to secrets repos
