### PR TITLE
Problem: CAS callback needs uWSGI request params

### DIFF
--- a/roles/configure-nginx/templates/tropo-uwsgi.conf.j2
+++ b/roles/configure-nginx/templates/tropo-uwsgi.conf.j2
@@ -6,5 +6,6 @@ location ~^/(application|maintenance|login|globus_login|oauth2.0/callbackAuthori
 }
 
 location ~^/cas/(oauth2.0|service) {
+    include {{ SNIPPETS_DIR }}/uwsgi_params;
     uwsgi_pass unix://{{ TROPO_UWSGI_SOCK }};
 }


### PR DESCRIPTION
## Description

For the location that uses the authentication location, the request were not coming in with the necessary uWSGI parameters. 

```
Message
KeyError: u'REQUEST_METHOD'
```

This happens within the WSGI callable when trying to index into the the `environ`. There is not key for `'REQUEST_METHOD'`. This will appear in the outside world as a `502 Bad Gateway` within nginx (you can see this in error.log).

The work includes the `uwsgi_params` for the auth callback, and all is well. 

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated (README.md and dist_files/variables.yml.dist)~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~Updated CHANGELOG.md~
- [ ] ~New variables committed to secrets repos~
