### PR TITLE
Prefer builtin celeryd restart over custom restart

### DIFF
--- a/roles/setup-celery/templates/celeryd.j2
+++ b/roles/setup-celery/templates/celeryd.j2
@@ -164,6 +164,31 @@ start() {
         $CELERYD_OPTS;
 }
 
+# `celeryd restart` sends a TERM signal, which will wait for running tasks to stop on
+# workers and restart them, if run a second time workers will forcefully restart
+restart() {
+
+    # Restart unprivileged workers
+    sudo -u "$CELERYD_USER" \
+        PATH="$CELERY_CHDIR:$VIRTUALENV/bin:$VIRTUALENV/lib/python2.7/site-packages:$PATH" \
+        PYTHONPATH="$CELERY_CHDIR:$PYTHONPATH" \
+        DJANGO_SETTINGS_MODULE="atmosphere.settings" \
+        "$CELERY_BIN" multi restart \
+            $CELERYD_NODES \
+            $CELERYD_WORKER_OPTS \
+            $CELERYD_OPTS;
+
+    # Start privileged (root) workers
+    C_FORCE_ROOT=1 \
+    PATH="$CELERY_CHDIR:$VIRTUALENV/bin:$VIRTUALENV/lib/python2.7/site-packages:$PATH" \
+    PYTHONPATH="$CELERY_CHDIR:$PYTHONPATH" \
+    DJANGO_SETTINGS_MODULE="atmosphere.settings" \
+    "$CELERY_BIN" multi restart \
+        $CELERYD_PRIVILEGED_NODES \
+        $CELERYD_PRIVILEGED_WORKER_OPTS \
+        $CELERYD_OPTS;
+}
+
 stop() {
 
     local nodes="$CELERYD_NODES $CELERYD_PRIVILEGED_NODES" \
@@ -251,7 +276,7 @@ case "$1" in
 
     status) status; ;;
 
-    restart) stop; start; ;;
+    restart) restart; ;;
 
     *) usage; ;;
 esac


### PR DESCRIPTION
Problem:
The celeryd init script force kills after a few seconds, which is not ideal for production

Solution:
Use the builtin celeryd restart, which doesn't force kill, until it is run a second time.

This just copies the start command and replaces the celeryd argument "start" with "multi". There is a lot of baggage required to run each command. Part of the reason is that an init script gets loaded once, and every service restart etc, continues to use the same environment. So its wise to not source a virtualenv, or export a variable like `C_FORCE_ROOT`.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated (README.md and dist_files/variables.yml.dist)
- [ ] Reviewed and approved by at least one other contributor.
- [ ] Updated CHANGELOG.md
- [ ] New variables committed to secrets repos
