### PR TITLE
Add 'kernel' tag to 'app-alter-kernel-for-imaging' role

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ Clank's install process is separated into three parts: installation of
 dependencies, atmosphere, and troposphere. To run specific parts of the
 deployment process, pass a comma separated list to the `--tags` option.
 
-Supported tags: `dependencies`, `atmosphere`, `troposphere`
+Supported tags: `dependencies`, `atmosphere`, `troposphere`, `kernel`
+
+Note: `kernel` tag is only attached to the `app-alter-kernel-for-imaging` role in the `setup_atmosphere.yml` playbook so that it can be skipped in Docker build environments.
 
 ```bash
 ansible-playbook playbooks/deploy_stack.yml -e @/path/to/my/clank-variables.yml --tags dependencies,troposphere

--- a/playbooks/setup_atmosphere.yml
+++ b/playbooks/setup_atmosphere.yml
@@ -3,7 +3,7 @@
   hosts: atmosphere
   roles:
     - { role: app-alter-kernel-for-imaging,
-        tags: ['atmosphere'] }
+        tags: ['atmosphere', 'kernel'] }
 
     - { role: app-config-postgres,
         DBNAME: "{{ ATMO_DBNAME | default(atmosphere_database_name) }}",


### PR DESCRIPTION
## Description

This PR just adds the `kernel` tag to the `setup_atmosphere.yml` playbook's use of role `app-alter-kernel-for-imaging` so I can skip this role in Docker. I also added some info to the README next to the info about other tags.

Docker does not allow kernel modification, so I have to skip this role in my Docker build, but it is not maintainable to use `sed -i '5,6d' playbooks/setup_atmosphere.yml` to delete the lines.