### PR TITLE
WIP: Supporting multiple hostnames for Atmosphere(1) server

### DIFF
--- a/dist_files/variables.yml.dist
+++ b/dist_files/variables.yml.dist
@@ -55,6 +55,10 @@ VIRTUAL_ENV_DIR: "/opt/env"  #NOTE: This is where atmosphere/troposphere virtual
 # TLS_LETSENCRYPT_ENABLE: true
 # TLS_LETSENCRYPT_EMAIL: "{{ ADMINS_EMAIL_TUPLE[0][1] }}"
 
+# Optional hostnames that django will whitelist. It is used so that django will
+# accept requests from a staging domain name and a production domain name
+# ADDITIONAL_ALLOWED_HOSTNAMES: ['your.domain.org', 'your-staging.domain.org']
+
 ###############################
 # 2. Authentication:
 # LDAP, JWT, and SAML are additional protocols that support Atmosphere API Only.

--- a/group_vars/atmosphere
+++ b/group_vars/atmosphere
@@ -30,6 +30,7 @@ ATMO:
         SERVER_URL: "{{ atmosphere_server_url }}"
         TOKEN_EXPIRY_TIME_DAYS: 1
         DJANGO_SERVER_URL: "{{ atmosphere_server_url }}"
+        ADDITIONAL_ALLOWED_HOSTNAMES: "{{ ADDITIONAL_ALLOWED_HOSTNAMES | default([]) }}"
 
     local.py:
         ANSIBLE_ROOT: "{{ ANSIBLE_DEPLOY_LOCATION | default(atmosphere_ansible_directory_path) }}"

--- a/group_vars/troposphere
+++ b/group_vars/troposphere
@@ -27,6 +27,7 @@ TROPO:
         ASSETS_PATH: "{{ TROPOSPHERE_LOCATION | default(troposphere_directory_path) }}/troposphere/assets"
         DJANGO_SERVER_URL: "{{ troposphere_server_url }}"
         SERVER_URL: "{{ troposphere_server_url }}"
+        ADDITIONAL_ALLOWED_HOSTNAMES: "{{ ADDITIONAL_ALLOWED_HOSTNAMES | default([]) }}"
         LDAP_SERVER: "{{ LDAP_SERVER | default('') }}"
         LDAP_SERVER_DN: "{{ LDAP_SERVER_DN | default('') }}"
         TOKEN_EXPIRY_TIME_DAYS: 1

--- a/playbooks/deploy_stack.yml
+++ b/playbooks/deploy_stack.yml
@@ -17,6 +17,7 @@
     - { role: configure-nginx,
         SERVER_URL: "{{ nginx_server_url }}",
         SITE_SERVER_NAME: "{{ server_name }}",
+        ALTERNATE_SERVER_NAMES: "{{ ADDITIONAL_ALLOWED_HOSTNAMES|default([]) }}",
         LOCATIONS: "{{ nginx_locations }}",
         SSL_KEY: "{{ TLS_PRIVKEY_PATH }}",
         SSL_CERT: "{{ TLS_FULLCHAIN_PATH }}",

--- a/roles/configure-nginx/README.md
+++ b/roles/configure-nginx/README.md
@@ -19,6 +19,8 @@ Role Variables
 |-------------------------|----------|---------|---------|-------------------------------------------------|
 | LOCATIONS               | yes      | []      |         | See below for more info                         |
 | SERVER_URL              | yes      |         |         | Ex. https://local.atmo.cloud                    |
+| SITE_SERVER_NAME        | yes      |         |         | Principal hostname for this server              |
+| ALTERNATE_SERVER_NAMES  | no       | []      |         | See below for more info                         |
 | SSL_KEY                 | yes      |         |         | Path to the key for certificate                 |
 | SSL_CERT                | yes      |         |         | Path to the full certificate chain              |
 | SSL_CACHAIN_CERT        | no       |         |         | See below for more info                         |
@@ -32,6 +34,11 @@ Role Variables
 | JENKINS_SERVER_URL      | no       |         |         | See below for more info                         |
 | FLOWER_SERVER_URL       | no       |         |         | See below for more info                         |
 
+`SITE_SERVER_NAME` a server name that nginx will use to identify if the nginx
+server definition should handle the request.
+
+`ALTERNATE_SERVER_NAMES` an optional list of alternate server names. See
+`SITE_SERVER_NAME`.
 
 `ENABLE_STRICT_TRANSPORT` instructs browsers to only accept valid HTTPS (see
 [HSTS](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security)). If

--- a/roles/configure-nginx/defaults/main.yml
+++ b/roles/configure-nginx/defaults/main.yml
@@ -10,6 +10,7 @@ SITES_ENABLED_DIR: /etc/nginx/sites-enabled
 SITES_AVAILABLE_DIR: /etc/nginx/sites-available
 LOCATIONS_DIR: /etc/nginx/locations
 SNIPPETS_DIR: /etc/nginx/snippets
+ALTERNATE_SERVER_NAMES: []
 
 TROPO_UWSGI_SOCK: /tmp/troposphere.sock
 ATMO_UWSGI_SOCK: /tmp/atmosphere.sock

--- a/roles/configure-nginx/templates/site.conf.j2
+++ b/roles/configure-nginx/templates/site.conf.j2
@@ -6,7 +6,7 @@ server {
 server {
     listen   443 {{ "ssl" if ENABLE_HTTP2 }};
 
-    server_name {{ SITE_SERVER_NAME }};
+    server_name {{ SITE_SERVER_NAME }} {{ ALTERNATE_SERVER_NAMES | join(' ') }};
     charset utf-8;
 
     ssl    on;
@@ -60,15 +60,6 @@ server {
         image/x-icon
         text/css
         text/plain;
-
-    # Deny illegal Host headers
-    if ($host !~* ^({{ SITE_SERVER_NAME }})$ ) {
-        return 444;
-        # 444 == No Response (Nginx):
-        # returns no information to the client
-        # and closes the connection
-        # (useful as a deterrent for malware)
-    }
 
 {% for name in LOCATIONS %}
     include {{ LOCATIONS_DIR }}/{{ name }}.conf;


### PR DESCRIPTION
## Description

Allows an atmosphere(1) server to answer on multiple hostnames so that we can do rolling deployments to a fresh instance and fast cutovers during a short maintenance period.

Co-depends on [atmosphere #602](https://github.com/cyverse/atmosphere/pull/602) and [troposphere #771](https://github.com/cyverse/troposphere/pull/771).

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [x] Documentation created/updated (README.md and dist_files/variables.yml.dist)
- [ ] Reviewed and approved by at least one other contributor.
- [ ] Updated CHANGELOG.md
- [ ] New variables committed to secrets repos
