### PR TITLE
Create backups in a single directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Changed
   - Updated changelog format, i.e. to adopt process to update changelog per pull request ([#256](https://github.com/cyverse/clank/pull/256))
+  - Database and configuration backups are stored in the same folder ([#258](https://github.com/cyverse/clank/pull/258))
 
 ### Fixed
   - Broken build resulting from lack of support for pip 10 ([#259](https://github.com/cyverse/clank/pull/259))

--- a/playbooks/utils/backup_db.yml
+++ b/playbooks/utils/backup_db.yml
@@ -1,13 +1,9 @@
 ---
 - name: Checking for necessary --extra_vars
   hosts: all
-  vars:
-    example:
-      - "-e \"{database_names: ['atmosphere', 'troposphere']}\""
-      - "-e \"BACKUP_PATH=/var/lib/postgresql/backups\""
   tasks:
-
-    - debug: msg="Consider passing in `database_names`"
+    - fail:
+        msg: "Variable `database_names` is required, try -e \"{database_names: ['atmo_prod', 'troposphere']}\""
       when: database_names is undefined or database_names == []
 
 - name: Ensure PostgreSQL service available

--- a/roles/app-backup-postgres/README.md
+++ b/roles/app-backup-postgres/README.md
@@ -11,8 +11,8 @@ None.
 Role Variables
 --------------
 
-- `database_names` - list of names of databases (defaults to `[]`)
-- 'BACKUP_PATH' - a path that resides underneath the postgres user owernship
+- `database_names` - list of names of databases (required)
+- 'BACKUP_PATH' - a directory where backups will be stored
 Dependencies
 ------------
 
@@ -44,12 +44,12 @@ Or, you can list multiple databases by name
             database_names: ['atmo_prod', 'troposphere'],
             tags: ['atmosphere', 'data-backup', 'backup'] }
 
-Specifing a path for the dumps to be save to. Be sure that path given resides under the postgresql's owernship
+Specifing a path for the dumps to be save to.
 
     - hosts: dbservers
       roles:
         - { role: app-backup-postgres,
-            BACKUP_PATH: /var/lib/postgresql/backups_are_important
+            BACKUP_PATH: /root/atmo_backups
             database_names: ['atmo_prod', 'troposphere'],
             tags: ['atmosphere', 'data-backup', 'backup'] }
 

--- a/roles/app-backup-postgres/defaults/main.yml
+++ b/roles/app-backup-postgres/defaults/main.yml
@@ -2,4 +2,4 @@
 # defaults file for app-backup-postgres
 
 database_names: []
-BACKUP_PATH: /var/lib/postgresql/backups
+BACKUP_PATH: /root/atmo_backups

--- a/roles/app-backup-postgres/tasks/main.yml
+++ b/roles/app-backup-postgres/tasks/main.yml
@@ -10,23 +10,16 @@
     mode: 0770
 
 - name: Backup all tables (including system tables)
-  become: yes
-  become_user: postgres
   args:
     chdir: "{{ BACKUP_PATH }}/{{ ansible_date_time.date }}"
-  command: >
-    pg_dumpall -f "{{ ansible_hostname }}-all-backup-{{ ansible_date_time.date }}-{{ ansible_date_time.epoch }}.sql"
+    warn: no
+  shell: >
+    sudo -u postgres pg_dumpall > "{{ ansible_hostname }}-all-backup-{{ ansible_date_time.date }}-{{ ansible_date_time.epoch }}.sql"
 
 - name: Backup specific tables ({{ database_names }})
-  become: yes
-  become_user: postgres
   args:
     chdir: "{{ BACKUP_PATH }}/{{ ansible_date_time.date }}"
+    warn: no
   with_items: "{{ database_names }}"
-  command: >
-    pg_dump {{ item }} -f "{{ ansible_hostname }}-{{ item }}-backup-{{ ansible_date_time.date }}-{{ ansible_date_time.epoch }}.sql"
-
-# The following task is helpful for copying the backup directory to a location that the postgresql user normally can't copy to
-- name: Copy backup to specific location when NEW_BACKUP_LOCATION var is defined
-  command: mv "{{ BACKUP_PATH }}/{{ ansible_date_time.date }}" {{ NEW_BACKUP_LOCATION }}
-  when: NEW_BACKUP_LOCATION is defined
+  shell: >
+    sudo -u postgres pg_dump {{ item }} > "{{ ansible_hostname }}-{{ item }}-backup-{{ ansible_date_time.date }}-{{ ansible_date_time.epoch }}.sql"

--- a/roles/app-backup-postgres/tasks/main.yml
+++ b/roles/app-backup-postgres/tasks/main.yml
@@ -23,3 +23,6 @@
   with_items: "{{ database_names }}"
   shell: >
     sudo -u postgres pg_dump {{ item }} > "{{ ansible_hostname }}-{{ item }}-backup-{{ ansible_date_time.date }}-{{ ansible_date_time.epoch }}.sql"
+
+- debug:
+    msg: "Table backups stored in {{ BACKUP_PATH }}/{{ ansible_date_time.date }}"

--- a/roles/app-backup-postgres/tasks/main.yml
+++ b/roles/app-backup-postgres/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for app-backup-postgres
-
 - name: Create "backups" directory
   file:
     path: "{{ BACKUP_PATH }}/{{ ansible_date_time.date }}"


### PR DESCRIPTION
## Description
### Problem
Database backups were made in a separate folder from the configuration backups.

### Solution
Change the default backup folder, and fix postrgresql permission limitations

I think this is just a small improvement, along with an echo of where the backups are made, which will be helpful with the new deploy process, where we will be making backups on prod, and then installing those on the staging.

## Checklist before merging Pull Requests
- [x] Documentation created/updated (README.md and dist_files/variables.yml.dist)
- [x] Reviewed and approved by at least one other contributor.
- [x] Updated CHANGELOG.md