### PR TITLE
Sanitary SQL Access tweaks for Jetstream Cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/clank/compare/v32-0...HEAD)
+### Fixed
+- Tweaks for `sanitary-sql-access` role to work on all production deployments ([#261](https://github.com/cyverse/clank/pull/261))
+
 ## [v32-0](https://github.com/cyverse/clank/compare/v31-0...v32-0) - 2018-04-23
 ### Added
   - Add 'kernel' tag, so that in a Docker context that tag can be skipped ([#255](https://github.com/cyverse/clank/pull/255))

--- a/roles/sanitary-sql-access/templates/sanitize-dump.sh.j2
+++ b/roles/sanitary-sql-access/templates/sanitize-dump.sh.j2
@@ -15,16 +15,14 @@ pg_dump {{ atmosphere_database_name }} | psql tmp_sanitary_db;
 # Sanitize db
 psql tmp_sanitary_db <<'EOF'
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
-UPDATE access_token SET key = 'KEY_REDACTED';
 UPDATE atmosphere_user SET password = 'PASSWORD_REDACTED';
 UPDATE ssh_key SET pub_key = 'PUB_KEY_REDACTED';
-UPDATE auth_token SET key = 'KEY_REDACTED_' || uuid_generate_v4();
-UPDATE auth_userproxy SET "proxyIOU" = 'proxyIOU_REDACTED', "proxyTicket" = 'proxyTicket_REDACTED';
 UPDATE boot_script SET title = 'title_REDACTED', script_text = 'script_text_REDACTED';
 UPDATE credential SET key = 'key_REDACTED', value = 'value_REDACTED';
 UPDATE django_admin_log SET change_message = 'change_message_REDACTED', object_repr = 'object_repr_REDACTED';
 UPDATE django_cyverse_auth_accesstoken SET key = 'KEY_REDACTED';
-UPDATE django_cyverse_auth_token SET key = 'KEY_REDACTED_' || uuid_generate_v4();
+-- This one tends to have millions of rows so we drop the secret column rather than overwriting it
+ALTER TABLE django_cyverse_auth_token DROP COLUMN key CASCADE;
 UPDATE django_cyverse_auth_userproxy SET "proxyIOU" = 'proxyIOU_REDACTED', "proxyTicket" = 'proxyTicket_REDACTED';
 UPDATE django_session SET session_key = 'RDD_' || uuid_generate_v4(), session_data = 'session_data_REDACTED';
 UPDATE external_link SET title = 'title_REDACTED', link = 'link_REDACTED', description = 'description_REDACTED';
@@ -35,6 +33,15 @@ UPDATE node_controller SET private_ssh_key = 'private_ssh_key_REDACTED';
 UPDATE provider SET cloud_config = NULL;
 UPDATE provider_credential SET key = 'key_REDACTED', value = 'value_REDACTED';
 EOF
+
+# These commands may fail (tables may not exist on all deployments), so always exit 0 and suppress stderr
+QUERYMAYFAIL=`cat << EOF
+UPDATE access_token SET key = 'KEY_REDACTED';
+UPDATE auth_token SET key = 'KEY_REDACTED_' || uuid_generate_v4();
+UPDATE auth_userproxy SET "proxyIOU" = 'proxyIOU_REDACTED', "proxyTicket" = 'proxyTicket_REDACTED';
+EOF
+`
+psql tmp_sanitary_db "$QUERYMAYFAIL" 2>/dev/null | true
 
 # Create sanitary dump
 pg_dump tmp_sanitary_db > /tmp/{{ atmosphere_database_name }}-sanitized.sql;


### PR DESCRIPTION
## Description

Fixing bugs and quirks so that the `sanitary-sql-access` role will work on all production deployments.

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [x] Updated CHANGELOG.md
- [ ] ~Documentation created/updated (include links)~
- [x] Reviewed and approved by at least one other contributor.
- [ ] ~New variables committed to secrets repos~