### PR TITLE
ATMO-2149: Atmosphere deploy without Subspace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@
       -e @variables.yml
       -e "atmosphere_github_branch=\"${ATMO_GITHUB_BRANCH:-master}\""
       -e "atmosphere_github_repo=\"${ATMO_GITHUB_REPO:-https://github.com/CyVerse/atmosphere.git}\""
+      -e "atmosphere_ansible_github_branch=\"${ANSIBLE_GITHUB_BRANCH:-master}\""
+      -e "atmosphere_ansible_github_repo=\"${ANSIBLE_GITHUB_REPO:-https://github.com/CyVerse/atmosphere-ansible.git}\""
       -e "troposphere_github_branch=\"${TROPO_GITHUB_BRANCH:-master}\""
       -e "troposphere_github_repo=\"${TROPO_GITHUB_REPO:-https://github.com/CyVerse/troposphere.git}\""
       --skip-tags "distro-update,enable-services"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/clank/compare/v32-0...HEAD)
+### Changed
+- Names of `group_vars` changed to use `ANSIBLE` in place of `SUBSPACE` ([#262](https://github.com/cyverse/clank/pull/262))
+
 ### Fixed
 - Tweaks for `sanitary-sql-access` role to work on all production deployments ([#261](https://github.com/cyverse/clank/pull/261))
 

--- a/group_vars/atmosphere
+++ b/group_vars/atmosphere
@@ -208,7 +208,7 @@ ATMOSPHERE_ANSIBLE:
         ANSIBLE_FACT_CACHE_TIMEOUT: 14400
         ANSIBLE_MANAGED_STR: "Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}"
         ANSIBLE_SSH_TIMEOUT: 10
-        SUBSPACE_PLUGINS_DIR: "{{ atmosphere_virtualenv_path }}/lib/python2.7/site-packages/subspace/plugins"
-        SUBSPACE_CALLBACK_WHITELIST: play_logger
-        SUBSPACE_COW_SELECTION: random
-        SUBSPACE_NO_COWS: 1
+        ANSIBLE_PLUGINS_DIR: "{{ atmosphere_ansible_directory_path }}/ansible/plugins"
+        ANSIBLE_CALLBACK_WHITELIST: atmo_logger
+        ANSIBLE_COW_SELECTION: random
+        ANSIBLE_NO_COWS: 1


### PR DESCRIPTION
## Description

Replace Subspace by using Ansible's PlaybookCLI to deploy instances.

In order to be compatible with the related branches of Atmoshere and Atmosphere-Ansible, names of variables in `group_vars` were changed to replace `SUBSPACE` with `ANSIBLE` since Subspace is no longer used.

Related PRs:
  - [Atmosphere PR #631](https://github.com/cyverse/atmosphere/pull/631)
  - [Atmosphere-Ansible PR #154](https://github.com/cyverse/atmosphere-ansible/pull/154)