### PR TITLE
Correctly find atmo deploy key in local secrets repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,22 +26,31 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased](https://github.com/cyverse/clank/compare/v32-0...HEAD)
 ### Changed
-- Names of `group_vars` changed to use `ANSIBLE` in place of `SUBSPACE` ([#262](https://github.com/cyverse/clank/pull/262))
+  - Names of `group_vars` changed to use `ANSIBLE` in place of `SUBSPACE`
+    ([#262](https://github.com/cyverse/clank/pull/262))
 
 ### Fixed
-- Tweaks for `sanitary-sql-access` role to work on all production deployments ([#261](https://github.com/cyverse/clank/pull/261))
+  - Tweaks for `sanitary-sql-access` role to work on all production
+    deployments ([#261](https://github.com/cyverse/clank/pull/261))
+  - Copy atmo deploy key from local secrets repo to target path
+    ([#263](https://github.com/cyverse/clank/pull/263))
 
 ## [v32-0](https://github.com/cyverse/clank/compare/v31-0...v32-0) - 2018-04-23
 ### Added
-  - Add 'kernel' tag, so that in a Docker context that tag can be skipped ([#255](https://github.com/cyverse/clank/pull/255))
-  - Support multiple hostnames for Atmosphere(1) server ([#257](https://github.com/cyverse/clank/pull/257))
+  - Add 'kernel' tag, so that in a Docker context that tag can be skipped
+    ([#255](https://github.com/cyverse/clank/pull/255))
+  - Support multiple hostnames for Atmosphere(1) server
+    ([#257](https://github.com/cyverse/clank/pull/257))
 
 ### Changed
-  - Updated changelog format, i.e. to adopt process to update changelog per pull request ([#256](https://github.com/cyverse/clank/pull/256))
-  - Database and configuration backups are stored in the same folder ([#258](https://github.com/cyverse/clank/pull/258))
+  - Updated changelog format, i.e. to adopt process to update changelog per
+    pull request ([#256](https://github.com/cyverse/clank/pull/256))
+  - Database and configuration backups are stored in the same folder
+    ([#258](https://github.com/cyverse/clank/pull/258))
 
 ### Fixed
-  - Broken build resulting from lack of support for pip 10 ([#259](https://github.com/cyverse/clank/pull/259))
+  - Broken build resulting from lack of support for pip 10
+    ([#259](https://github.com/cyverse/clank/pull/259))
 
 ## [v31-0](https://github.com/cyverse/clank/compare/v30-2...v31-0) - 2018-03-19
 ### Added

--- a/roles/app-setup-ssh-keys/tasks/main.yml
+++ b/roles/app-setup-ssh-keys/tasks/main.yml
@@ -5,11 +5,15 @@
   file: path={{ APP_BASE_DIR }}/extras/ssh/ state=directory
 
 - name: Test the id_rsa_path exists
-  stat: path={{ SSH_PRIV_KEY }}
+  local_action:
+    module: stat
+    path: "{{ SSH_PRIV_KEY }}"
   register: id_rsa_path
 
 - name: Test the id_rsa_pub_path exists
-  stat: path={{ SSH_PUB_KEY }}
+  local_action:
+    module: stat
+    path: "{{ SSH_PUB_KEY }}"
   register: id_rsa_pub_path
 
 - name: Set CREATE_SSH True if either id_rsa_path/id_rsa_pub_path *do not exist*


### PR DESCRIPTION
## Description

### Problem
Ansible was not using the deploy key found in the secrets repo

### Solution
When checking if the deployer has a key to copy over, check locally, since the secrets repo is local

## Checklist before merging Pull Requests
- [x] Updated CHANGELOG.md
- [x] Reviewed and approved by at least one other contributor.