### PR TITLE
Fix nginx http to https redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/clank/compare/v33-0...HEAD) - YYYY-MM-DD
+### Fixed
+  - Fix the global http to https redirect in nginx
+    ([#267](https://github.com/cyverse/clank/pull/267))
+
 ## [v33-0](https://github.com/cyverse/clank/compare/v32-0...v33-0) - 2018-08-08
 ### Changed
   - Names of `group_vars` changed to use `ANSIBLE` in place of `SUBSPACE`

--- a/group_vars/common
+++ b/group_vars/common
@@ -7,7 +7,6 @@ virtualenv_dir: "{{VIRTUAL_ENV_DIR | default('/opt/env')}}"
 github_branch: master
 pg_version: 9.6
 server_name: "{{ SERVER_NAME | default(ansible_fqdn) }}"
-nginx_server_url: "https://{{ server_name }}"
 nginx_locations: ["atmo-uwsgi", "tropo-uwsgi", "flower", "tropo-assets-path", "robots"]
 staff_list_usernames: "{{ STAFF_LIST_USERNAMES | default([]) }}"
 maintenance_exempt_usernames: "{{ MAINTENANCE_EXEMPT_USERNAMES | default(staff_list_usernames) }}"

--- a/playbooks/deploy_stack.yml
+++ b/playbooks/deploy_stack.yml
@@ -15,7 +15,7 @@
   hosts: full_deploy
   roles:
     - { role: configure-nginx,
-        SERVER_URL: "{{ nginx_server_url }}",
+        SERVER_URL: "https://{{ server_name }}",
         SITE_SERVER_NAME: "{{ server_name }}",
         ALTERNATE_SERVER_NAMES: "{{ ADDITIONAL_ALLOWED_HOSTNAMES|default([]) }}",
         LOCATIONS: "{{ nginx_locations }}",

--- a/roles/configure-nginx/templates/site.conf.j2
+++ b/roles/configure-nginx/templates/site.conf.j2
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    return 301 https://{{ SERVER_URL }}$request_uri;
+    return 301 {{ SERVER_URL }}$request_uri;
 }
 
 server {


### PR DESCRIPTION
## Description
### Problem
Nginx incorrectly redirects users from http://<atmo server> to https://https://<atmo server>

### Solution
The template assumed that SERVER_URL did NOT include the protocol prefix
(https://). Correct the template to assume that SERVER_URL includes the protocol

## Checklist before merging Pull Requests
- [x] Updated CHANGELOG.md
- [x] Reviewed and approved by at least one other contributor.