### PR TITLE
Simplify SEND_EMAILS and DEBUG variables

### DIFF
--- a/group_vars/atmosphere
+++ b/group_vars/atmosphere
@@ -71,7 +71,7 @@ ATMO:
         DATABASE_PASSWORD: "{{ atmosphere_database_password }}"
         DATABASE_PORT: 5432
         DATABASE_USER: "{{ atmosphere_database_user }}"
-        DJANGO_DEBUG: "{{ DEBUG | default(True)}}"
+        DEBUG: "{{ DEBUG | default(False)}}"
         DJANGO_DEBUG_TOOLBAR: "{{ DJANGO_DEBUG_TOOLBAR | default(False)}}"
         ENFORCING: "{{ ENFORCING | default(False) }}"
         DJANGO_JENKINS: "{{ install_jenkins }}"

--- a/group_vars/atmosphere
+++ b/group_vars/atmosphere
@@ -75,6 +75,7 @@ ATMO:
         DJANGO_DEBUG_TOOLBAR: "{{ DJANGO_DEBUG_TOOLBAR | default(False)}}"
         ENFORCING: "{{ ENFORCING | default(False) }}"
         DJANGO_JENKINS: "{{ install_jenkins }}"
+        SEND_EMAILS: "{{ SEND_EMAILS | default(False) }}"
         SESSION_COOKIE_AGE:
         SSLSERVER: "{{ SSLSERVER | default(True) }}"
         TESTING: "{{ TESTING | default(False) }}"


### PR DESCRIPTION
## Description

1) Make SEND_EMAILS its own variable

SEND_EMAILS used to be derived from another variables, which makes configuration more difficult to reason about.

2) Change DJANGO_DEBUG name and default

Both troposphere and atmosphere have a global debug, they now have the same name. They now both default to False (used to have different defaults).


## Checklist before merging Pull Requests
- [ ] Updated CHANGELOG.md
- [ ] Reviewed and approved by at least one other contributor.
- [ ] New variables committed to secrets repos