### PR TITLE
Fix database loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Fixed
   - Fix the global http to https redirect in nginx
     ([#267](https://github.com/cyverse/clank/pull/267))
+  - Fixed database loading ([#269](https://github.com/cyverse/clank/pull/269))
 
 ### Changed
   - Variable changes to DJANGO_DEBUG and SEND_EMAILS

--- a/playbooks/setup_atmosphere.yml
+++ b/playbooks/setup_atmosphere.yml
@@ -9,7 +9,7 @@
         DBNAME: "{{ ATMO_DBNAME | default(atmosphere_database_name) }}",
         DBUSER: "{{ ATMO_DBUSER | default(atmosphere_database_user) }}",
         DBPASSWORD: "{{ ATMO_DBPASSWORD | default(atmosphere_database_password) }}",
-        LOAD_DATABASE: "ATMO_DATA.LOAD_DATABASE | default(False)",
+        LOAD_DATABASE: "{{ ATMO_DATA.LOAD_DATABASE | default(false) }}"
         tags: ['atmosphere', 'database'] }
 
     - { role: app-load-data-postgres,

--- a/playbooks/setup_atmosphere.yml
+++ b/playbooks/setup_atmosphere.yml
@@ -14,9 +14,8 @@
 
     - { role: app-load-data-postgres,
         DBNAME: "{{ ATMO_DBNAME | default(atmosphere_database_name) }}",
-        LOAD_DATABASE: "ATMO_DATA.LOAD_DATABASE | default(False)",
         DATABASE_FILE_TO_BE_LOADED: "{{ ATMO_DATA.SQL_DUMP_FILE }}",
-        when: ATMO_DATA is defined and ATMO_DATA.SQL_DUMP_FILE is defined and ATMO_DATA.LOAD_DATABASE is defined,
+        when: ATMO_DATA is defined and ATMO_DATA.SQL_DUMP_FILE is defined and (ATMO_DATA.LOAD_DATABASE|default(false)),
         tags: ['atmosphere', 'database', 'data-load'] }
 
     - { role: delete-files,

--- a/playbooks/setup_troposphere.yml
+++ b/playbooks/setup_troposphere.yml
@@ -12,9 +12,8 @@
 
     - { role: app-load-data-postgres,
         DBNAME: "{{ TROPO_DBNAME | default(troposphere_database_name) }}",
-        LOAD_DATABASE: "{{ TROPO_DATA.LOAD_DATABASE }}",
         DATABASE_FILE_TO_BE_LOADED: "{{ TROPO_DATA.SQL_DUMP_FILE }}",
-        when: TROPO_DATA is defined and TROPO_DATA.SQL_DUMP_FILE is defined and TROPO_DATA.LOAD_DATABASE,
+        when: TROPO_DATA is defined and TROPO_DATA.SQL_DUMP_FILE is defined and (TROPO_DATA.LOAD_DATABASE | default(false)),
         tags: ['troposphere', 'database', 'data-load'] }
 
     - { role: delete-files,

--- a/playbooks/setup_troposphere.yml
+++ b/playbooks/setup_troposphere.yml
@@ -7,6 +7,7 @@
         DBNAME: "{{ TROPO_DBNAME | default(troposphere_database_name) }}",
         DBUSER: "{{ TROPO_DBUSER | default(troposphere_database_user) }}",
         DBPASSWORD: "{{ TROPO_DBPASSWORD | default(troposphere_database_password) }}",
+        LOAD_DATABASE: "{{ TROPO_DATA.LOAD_DATABASE | default(false) }}",
         tags: ['troposphere', 'database'] }
 
     - { role: app-load-data-postgres,

--- a/roles/app-load-data-postgres/README.md
+++ b/roles/app-load-data-postgres/README.md
@@ -11,14 +11,7 @@ Requirements
 Role Variables
 --------------
 
-- `LOAD_DATABASE`
 - `DATABASE_FILE_TO_BE_LOADED`
-
-**Note:** `LOAD_DATABASE` remains so that when this role is composed into a
-setup scenario it can still be overidden by a variable in `extra_vars`. It
-likely will seem out-of-place, or unneeded. However, if a playbook (like, say,
-`setup-troposphere.yaml`) wants to optionally avoid _data loading_, then having
-it present in a parameterized manner gives the ability to skip the role.
 
 Dependencies
 ------------
@@ -32,7 +25,6 @@ Example Playbook
       roles:
         - { role: app-load-data-postgres,
             DBNAME: "{{ ATMO_DBNAME}} ",
-            LOAD_DATABASE: True,
             DATABASE_FILE_TO_BE_LOADED: "{{ SQL_DUMP_FILE }}" }
 ```
 

--- a/roles/app-load-data-postgres/tasks/main.yml
+++ b/roles/app-load-data-postgres/tasks/main.yml
@@ -1,14 +1,12 @@
 ---
 - name: copy over sql script for postgresql to run
   copy: src={{ DATABASE_FILE_TO_BE_LOADED }} dest={{ POSTGRES_SQL_INSTALL_DIRECTORY }}
-  when: LOAD_DATABASE
 
 - name: run sql script for postgresql
   become: yes
   become_user: postgres
   command: psql -d {{ DBNAME }} -f {{ TARGET_SQL_LOAD_FILE }}
-  when: LOAD_DATABASE
   register: output
 
 - debug: var=output.stdout_lines
-  when: (CLANK_VERBOSE | default(False)) and LOAD_DATABASE
+  when: CLANK_VERBOSE | default(False)


### PR DESCRIPTION
## Description

### Problem
- Troposphere database was not being deleted, because LOAD_DATABASE was not being passed
- Atmophsere database was not being deleted, because LOAD_DATABASE was not being passed properly

### Solution
- Pass variables properly
- Refactor role to remove variable which turns role off/on and use when clauses
  with role instead to selectively include it

## Checklist before merging Pull Requests
- [x] Updated CHANGELOG.md
- [ ] Reviewed and approved by at least one other contributor.