### PR TITLE
Problem: Enforcement overrides not configurable by Clank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/clank/compare/v33-0...HEAD) - YYYY-MM-DD
+### Added
+  - Add ability to configure allocation overrides
+    ([#270](https://github.com/cyverse/clank/pull/270))
+
 ### Fixed
   - Fix the global http to https redirect in nginx
     ([#267](https://github.com/cyverse/clank/pull/267))

--- a/group_vars/atmosphere
+++ b/group_vars/atmosphere
@@ -74,6 +74,8 @@ ATMO:
         DEBUG: "{{ DEBUG | default(False)}}"
         DJANGO_DEBUG_TOOLBAR: "{{ DJANGO_DEBUG_TOOLBAR | default(False)}}"
         ENFORCING: "{{ ENFORCING | default(False) }}"
+        ALLOCATION_OVERRIDES_NEVER_ENFORCE: "{{ ALLOCATION_OVERRIDES_NEVER_ENFORCE | default([]) }}"
+        ALLOCATION_OVERRIDES_ALWAYS_ENFORCE: "{{ ALLOCATION_OVERRIDES_ALWAYS_ENFORCE | default([]) }}"
         DJANGO_JENKINS: "{{ install_jenkins }}"
         SEND_EMAILS: "{{ SEND_EMAILS | default(False) }}"
         SESSION_COOKIE_AGE:


### PR DESCRIPTION
Solution: Add `ALLOCATION_OVERRIDES_NEVER_ENFORCE` and
`ALLOCATION_OVERRIDES_ALWAYS_ENFORCE` into group_vars/atmosphere

## Checklist before merging Pull Requests
- [x] Updated CHANGELOG.md
- [x] Reviewed and approved by at least one other contributor.
