### PR TITLE
Simplify vars send emails and debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
   - Fix the global http to https redirect in nginx
     ([#267](https://github.com/cyverse/clank/pull/267))
 
+### Changed
+  - Variable changes to DJANGO_DEBUG and SEND_EMAILS
+    ([#271](https://github.com/cyverse/clank/pull/271))
+
 ## [v33-0](https://github.com/cyverse/clank/compare/v32-0...v33-0) - 2018-08-08
 ### Changed
   - Names of `group_vars` changed to use `ANSIBLE` in place of `SUBSPACE`

--- a/group_vars/atmosphere
+++ b/group_vars/atmosphere
@@ -71,7 +71,7 @@ ATMO:
         DATABASE_PASSWORD: "{{ atmosphere_database_password }}"
         DATABASE_PORT: 5432
         DATABASE_USER: "{{ atmosphere_database_user }}"
-        DJANGO_DEBUG: "{{ DEBUG | default(True)}}"
+        DEBUG: "{{ DEBUG | default(False)}}"
         DJANGO_DEBUG_TOOLBAR: "{{ DJANGO_DEBUG_TOOLBAR | default(False)}}"
         ENFORCING: "{{ ENFORCING | default(False) }}"
         DJANGO_JENKINS: "{{ install_jenkins }}"

--- a/group_vars/atmosphere
+++ b/group_vars/atmosphere
@@ -75,6 +75,7 @@ ATMO:
         DJANGO_DEBUG_TOOLBAR: "{{ DJANGO_DEBUG_TOOLBAR | default(False)}}"
         ENFORCING: "{{ ENFORCING | default(False) }}"
         DJANGO_JENKINS: "{{ install_jenkins }}"
+        SEND_EMAILS: "{{ SEND_EMAILS | default(False) }}"
         SESSION_COOKIE_AGE:
         SSLSERVER: "{{ SSLSERVER | default(True) }}"
         TESTING: "{{ TESTING | default(False) }}"


### PR DESCRIPTION
## Description

1) Make SEND_EMAILS its own variable

SEND_EMAILS used to be derived from another variables, which makes configuration more difficult to reason about.

2) Change DJANGO_DEBUG name and default

Both troposphere and atmosphere have a global debug, they now have the same name. They now both default to False (used to have different defaults).

See https://github.com/cyverse/atmosphere/pull/649

## Checklist before merging Pull Requests
- [x] Updated CHANGELOG.md
- [ ] Reviewed and approved by at least one other contributor.
- [ ] New variables committed to secrets repos