### PR TITLE
Flatten nested ATMO_DATA and TROPO_DATA variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Changed
   - Variable changes to DJANGO_DEBUG and SEND_EMAILS
     ([#271](https://github.com/cyverse/clank/pull/271))
+  - Flattened TROPO_DATA and ATMO_DATA variables
+    ([#273](https://github.com/cyverse/clank/pull/273))
 
 ## [v33-0](https://github.com/cyverse/clank/compare/v32-0...v33-0) - 2018-08-08
 ### Changed

--- a/group_vars/atmosphere
+++ b/group_vars/atmosphere
@@ -193,9 +193,8 @@ ATMO:
         OPENSTACK_ADMIN_ROLE:
         ATMOSPHERE_SUPERUSER:
 
-ATMO_DATA:
-    LOAD_DATABASE:
-    SQL_DUMP_FILE:
+ATMO_LOAD_DATABASE: false
+ATMO_SQL_DUMP_FILE:
 
 ###################################
 #

--- a/group_vars/troposphere
+++ b/group_vars/troposphere
@@ -136,3 +136,6 @@ TROPO:
         # Enable/Disable Web Desktop and Guacamole for VNC/Shell functionality
         WEB_DESKTOP_ENABLED: "{{ WEB_DESKTOP_ENABLED | default(False) }}"
         GUACAMOLE_ENABLED: "{{ GUACAMOLE_ENABLED | default(False) }}"
+
+TROPO_LOAD_DATABASE: false
+TROPO_SQL_DUMP_FILE:

--- a/playbooks/setup_atmosphere.yml
+++ b/playbooks/setup_atmosphere.yml
@@ -9,13 +9,13 @@
         DBNAME: "{{ ATMO_DBNAME | default(atmosphere_database_name) }}",
         DBUSER: "{{ ATMO_DBUSER | default(atmosphere_database_user) }}",
         DBPASSWORD: "{{ ATMO_DBPASSWORD | default(atmosphere_database_password) }}",
-        LOAD_DATABASE: "{{ ATMO_DATA.LOAD_DATABASE | default(false) }}",
+        LOAD_DATABASE: "{{ ATMO_LOAD_DATABASE }}",
         tags: ['atmosphere', 'database'] }
 
     - { role: app-load-data-postgres,
         DBNAME: "{{ ATMO_DBNAME | default(atmosphere_database_name) }}",
-        DATABASE_FILE_TO_BE_LOADED: "{{ ATMO_DATA.SQL_DUMP_FILE }}",
-        when: ATMO_DATA is defined and ATMO_DATA.SQL_DUMP_FILE is defined and (ATMO_DATA.LOAD_DATABASE|default(false)),
+        DATABASE_FILE_TO_BE_LOADED: "{{ ATMO_SQL_DUMP_FILE }}",
+        when: ATMO_LOAD_DATABASE,
         tags: ['atmosphere', 'database', 'data-load'] }
 
     - { role: delete-files,

--- a/playbooks/setup_troposphere.yml
+++ b/playbooks/setup_troposphere.yml
@@ -7,13 +7,13 @@
         DBNAME: "{{ TROPO_DBNAME | default(troposphere_database_name) }}",
         DBUSER: "{{ TROPO_DBUSER | default(troposphere_database_user) }}",
         DBPASSWORD: "{{ TROPO_DBPASSWORD | default(troposphere_database_password) }}",
-        LOAD_DATABASE: "{{ TROPO_DATA.LOAD_DATABASE | default(false) }}",
+        LOAD_DATABASE: "{{ TROPO_LOAD_DATABASE }}",
         tags: ['troposphere', 'database'] }
 
     - { role: app-load-data-postgres,
         DBNAME: "{{ TROPO_DBNAME | default(troposphere_database_name) }}",
-        DATABASE_FILE_TO_BE_LOADED: "{{ TROPO_DATA.SQL_DUMP_FILE }}",
-        when: TROPO_DATA is defined and TROPO_DATA.SQL_DUMP_FILE is defined and (TROPO_DATA.LOAD_DATABASE | default(false)),
+        DATABASE_FILE_TO_BE_LOADED: "{{ TROPO_SQL_DUMP_FILE }}",
+        when: TROPO_LOAD_DATABASE,
         tags: ['troposphere', 'database', 'data-load'] }
 
     - { role: delete-files,


### PR DESCRIPTION
## Description
Prefer flat variables for database loading

#### Before
```
ATMO_DATA:
    LOAD_DATABASE: false
    SQL_DUMP_FILE:
TROPO_DATA:
    LOAD_DATABASE: false
    SQL_DUMP_FILE:
```
#### After
```
ATMO_LOAD_DATABASE: false
ATMO_SQL_DUMP_FILE:
TROPO_LOAD_DATABASE: false
TROPO_SQL_DUMP_FILE:
```

## Checklist before merging Pull Requests
- [x] Updated CHANGELOG.md
- [ ] Reviewed and approved by at least one other contributor.
- [ ] New variables committed to secrets repos
