### PR TITLE
Install smtp server to send outgoing emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Added
   - Add ability to configure allocation overrides
     ([#270](https://github.com/cyverse/clank/pull/270))
+  - Setup atmosphere to send mail
+    ([#274](https://github.com/cyverse/clank/pull/274))
 
 ### Changed
   - Variable changes to DJANGO_DEBUG and SEND_EMAILS

--- a/playbooks/prepare_host.yml
+++ b/playbooks/prepare_host.yml
@@ -6,3 +6,12 @@
       when: UPDATE_DISTRO | default(True)
   tags:
     - distro-update
+
+  tasks:
+    - name: "Set hostname to persist across reboots"
+      copy:
+        content: "{{ SERVER_NAME }}"
+        dest: "/etc/hostname"
+
+    - name: "Set hostname"
+      hostname: name="{{ SERVER_NAME }}"

--- a/roles/install-dependencies/tasks/main.yml
+++ b/roles/install-dependencies/tasks/main.yml
@@ -60,6 +60,11 @@
     - 'install'
     - 'apt-install'
 
+- name: Ensure outgoing smtp server is running
+  service:
+    name: sendmail
+    state: started
+
 - name: Lib packages installed
   package:
     name: '{{ item }}'

--- a/roles/install-dependencies/vars/Ubuntu.yml
+++ b/roles/install-dependencies/vars/Ubuntu.yml
@@ -160,6 +160,7 @@ DEV_PACKAGES:
   - python-pip
   - python-setuptools
   - ufw
+  - sendmail
 
 LIB_PACKAGES:
   - libxml2-dev


### PR DESCRIPTION
## Description
### Problem
Atmosphere emails were not being sent

### Solution
Install and start a local smtp server

Atmosphere depends on a local smtp server to send mail. See the Django
EMAIL_HOST variable[1].

[1] https://docs.djangoproject.com/en/2.1/ref/settings/#email-host

I tested that this playbook installs an smtp server and ensures its running

## Checklist before merging Pull Requests
- [x] Updated CHANGELOG.md
- [x] Reviewed and approved by at least one other contributor.
