### PR TITLE
Remove unused USE_ALLOCATION_SOURCE(S) variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Removed
   - Remove RELEASE and RELEASE_INITIALS variables
     ([#265](https://github.com/cyverse/clank/pull/265))
+  - Remove unused USE_ALLOCATION_SOURCE(S) variables
+    ([#275](https://github.com/cyverse/clank/pull/275))
   - Remove DEFAULT_ALLOCATION_{THRESHOLD,DELTA} variables
     ([#276](https://github.com/cyverse/clank/pull/276))
 

--- a/group_vars/atmosphere
+++ b/group_vars/atmosphere
@@ -123,7 +123,6 @@ ATMO:
         GROUPER_SEARCH_USER: "{{ GROUPER_SEARCH_USER | default('') }}"
         # Jetstream specific
         USE_JETSTREAM_PLUGIN: "{{ USE_JETSTREAM_PLUGIN | default(False) }}"
-        USE_ALLOCATION_SOURCE: "{{ USE_ALLOCATION_SOURCES | default(False) }}"
         TACC_API_USER: "{{ TACC_API_USER | default('') }}"
         TACC_API_PASS: "{{ TACC_API_PASS | default('') }}"
         TACC_API_URL: "{{ TACC_API_URL | default('') }}"

--- a/group_vars/troposphere
+++ b/group_vars/troposphere
@@ -121,7 +121,6 @@ TROPO:
         INTERCOM_COMPANY_ID: "{{ INTERCOM_COMPANY_ID | default('') }}"
         INTERCOM_COMPANY_NAME: "{{ INTERCOM_COMPANY_NAME | default('') }}"
 
-        USE_ALLOCATION_SOURCES: "{{ USE_ALLOCATION_SOURCE | default(False) }}"
         EXTERNAL_ALLOCATION: "{{ EXTERNAL_ALLOCATION | default(True) }}"
         ALLOCATION_UNIT_NAME: "{{ ALLOCATION_UNIT_NAME | default('Allocation Unit') }}"
         ALLOCATION_UNIT_ABBREV: "{{ ALLOCATION_UNIT_ABBREV | default('AU') }}"


### PR DESCRIPTION
## Description

Remove traces of `USE_ALLOCATION_SOURCES`. This variable allowed us to transition from the old allocation system to the new one. We no longer use the old one and can remove all this variable's references.


## Checklist before merging Pull Requests
- [x] Updated CHANGELOG.md
- [ ] Reviewed and approved by at least one other contributor.
- [x] New variables committed to secrets repos