### PR TITLE
Remove unused variables DEFAULT_ALLOCATION_{THRESHOLD,DELTA}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Removed
   - Remove RELEASE and RELEASE_INITIALS variables
     ([#265](https://github.com/cyverse/clank/pull/265))
+  - Remove DEFAULT_ALLOCATION_{THRESHOLD,DELTA} variables
+    ([#276](https://github.com/cyverse/clank/pull/276))
 
 ### Fixed
   - Fix the global http to https redirect in nginx

--- a/group_vars/atmosphere
+++ b/group_vars/atmosphere
@@ -129,8 +129,6 @@ ATMO:
         TACC_API_URL: "{{ TACC_API_URL | default('') }}"
         # Marked for deletion POST "Per-Provider defaults"
         DEFAULT_EMAIL_DOMAIN: "{{ DEFAULT_EMAIL_DOMAIN | default('') }}"
-        DEFAULT_ALLOCATION_THRESHOLD: "{{ DEFAULT_ALLOCATION_THRESHOLD | default(10080) }}"
-        DEFAULT_ALLOCATION_DELTA: "{{ DEFAULT_ALLOCATION_DELTA | default(525600) }}"
         DEFAULT_QUOTA: "{{ DEFAULT_QUOTA | default('') }}"
         DEFAULT_IP_LOOKUP: "{{ DEFAULT_IP_LOOKUP | default('iplant_hostname') }}"
         DEFAULT_PASSWORD_LOOKUP:


### PR DESCRIPTION
## Description

Remove variables that were relevant to old allocation system. Depends on https://github.com/cyverse/atmosphere/pull/656.

## Checklist before merging Pull Requests
- [x] Updated CHANGELOG.md
- [x] Reviewed and approved by at least one other contributor.
- [x] New variables committed to secrets repos