### PR TITLE
Rename TACC_API_TIMEOUT to TACC_READ_API_TIMEOUT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/clank/compare/v34-0...HEAD) - YYYY-MM-DD
+  - Rename TACC_API_TIMEOUT to TACC_READ_API_TIMEOUT
+    ([#278](https://github.com/cyverse/clank/pull/278))
+
 ## [v34-0](https://github.com/cyverse/clank/compare/v33-0...v34-0) - 2018-09-17
 ### Added
   - Add ability to configure allocation overrides

--- a/group_vars/atmosphere
+++ b/group_vars/atmosphere
@@ -126,7 +126,7 @@ ATMO:
         TACC_API_USER: "{{ TACC_API_USER | default('') }}"
         TACC_API_PASS: "{{ TACC_API_PASS | default('') }}"
         TACC_API_URL: "{{ TACC_API_URL | default('') }}"
-        TACC_API_TIMEOUT: 5
+        TACC_READ_API_TIMEOUT: 5
         # Marked for deletion POST "Per-Provider defaults"
         DEFAULT_EMAIL_DOMAIN: "{{ DEFAULT_EMAIL_DOMAIN | default('') }}"
         DEFAULT_QUOTA: "{{ DEFAULT_QUOTA | default('') }}"


### PR DESCRIPTION
## Description

`TACC_API_TIMEOUT` was replaced in favor of `TACC_READ_API_TIMEOUT` because it
only applied to GETs

Related: https://github.com/cyverse/atmosphere/pull/668

## Checklist before merging Pull Requests
- [x] Updated CHANGELOG.md
- [ ] Reviewed and approved by at least one other contributor.
- [x] New variables committed to secrets repos
  - This variable is not actually configurable, because ansible cannot template numbers