### PR TITLE
ATMO-2160: Install libguestfs-tools for new Chromogenic

### DIFF
--- a/roles/install-dependencies/vars/Ubuntu.yml
+++ b/roles/install-dependencies/vars/Ubuntu.yml
@@ -147,6 +147,7 @@ DEV_PACKAGES:
   - postgresql-contrib-{{ pg_version | default('9.6') }}
   - postgresql-server-dev-{{ pg_version | default('9.6') }}
   - python-psycopg2
+  - libguestfs-tools
   - libpq-dev
   - python-dev
   - libldap2-dev


### PR DESCRIPTION
## Description

Install libguestfs-tools so that Chromogenic can use virt-sysprep for imaging.

This is required after merging [Chromogenic PR #14](https://github.com/cyverse/chromogenic/pull/14), creating a new version, and creating a new Atmosphere PR to use this new version.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Updated CHANGELOG.md
- [ ] Documentation created/updated (include links)
- [ ] Reviewed and approved by at least one other contributor.
- [ ] New variables committed to secrets repos
