### PR TITLE
Make sanitary-sql-access role compatible with Atmosphere Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
     ([#278](https://github.com/cyverse/clank/pull/278))
   - Cleanup email variables, remove unused, change SUPPORT_EMAIL
     ([#280](https://github.com/cyverse/clank/pull/280))
+  - Changed sanitary-sql-access role to be compatible with atmosphere-docker
+    ([287](https://github.com/cyverse/clank/pull/287))
 
 ## [v34-0](https://github.com/cyverse/clank/compare/v33-0...v34-0) - 2018-09-17
 ### Added

--- a/roles/sanitary-sql-access/tasks/main.yml
+++ b/roles/sanitary-sql-access/tasks/main.yml
@@ -1,26 +1,5 @@
 ---
 
-- name: sanitize-dump script deployed
-  template:
-    src: 'sanitize-dump.sh.j2'
-    dest: '/var/lib/postgresql/sanitize-dump.sh'
-    owner: 'postgres'
-    mode: 'u+x'
-
-- name: sanitize-dump script scheduled via cron
-  cron:
-    name: 'sanitize-dump-db'
-    special_time: 'daily'
-    job: '/var/lib/postgresql/sanitize-dump.sh'
-    user: 'postgres'
-
-- name: sanitize-dump script ran once
-  shell: '/var/lib/postgresql/sanitize-dump.sh'
-  become: true
-  become_user: 'postgres'
-  register: command_result
-  failed_when: 'command_result.rc != 0'
-
 # Unix user
 
 - name: sanitarysql user created
@@ -48,3 +27,24 @@
   file:
     path: '/home/sanitarysql/.hushlogin'
     state: 'touch'
+
+# Scripts
+
+- name: sanitize-dump script deployed
+  template:
+    src: 'sanitize-dump.sh.j2'
+    dest: '/home/sanitarysql/sanitize-dump.sh'
+    owner: 'sanitarysql'
+    mode: 'u+x'
+
+- name: sanitize-dump script scheduled via cron
+  cron:
+    name: 'sanitize-dump-db'
+    special_time: 'daily'
+    job: '/home/sanitarysql/sanitize-dump.sh'
+    user: 'root'
+
+- name: sanitize-dump script ran once
+  shell: '/home/sanitarysql/sanitize-dump.sh'
+  register: command_result
+  failed_when: 'command_result.rc != 0'

--- a/roles/sanitary-sql-access/templates/sanitize-dump.sh.j2
+++ b/roles/sanitary-sql-access/templates/sanitize-dump.sh.j2
@@ -3,17 +3,19 @@
 # Exit if any command fails
 set -e;
 
+exec='docker-compose -f /opt/dev/atmosphere-docker/docker-compose.prod.yml exec -T postgres'
+
 # Create temporary database used to create database dump
-createdb tmp_sanitary_db;
+$exec createdb -U atmo_app tmp_sanitary_db;
 
 # If we exit for any reason (including end of this script), remove the temporary database
-trap 'dropdb tmp_sanitary_db' EXIT;
+trap '$exec dropdb -U atmo_app tmp_sanitary_db' EXIT;
 
 # Dump production database and load into temporary database
-pg_dump {{ atmosphere_database_name }} | psql tmp_sanitary_db;
+$exec pg_dump -U atmo_app {{ atmosphere_database_name }} | $exec psql -U atmo_app tmp_sanitary_db;
 
 # Sanitize db
-psql tmp_sanitary_db <<'EOF'
+$exec psql -U atmo_app tmp_sanitary_db <<'EOF'
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 UPDATE atmosphere_user SET password = 'PASSWORD_REDACTED';
 UPDATE ssh_key SET pub_key = 'PUB_KEY_REDACTED';
@@ -41,7 +43,8 @@ UPDATE auth_token SET key = 'KEY_REDACTED_' || uuid_generate_v4();
 UPDATE auth_userproxy SET "proxyIOU" = 'proxyIOU_REDACTED', "proxyTicket" = 'proxyTicket_REDACTED';
 EOF
 `
-psql tmp_sanitary_db "$QUERYMAYFAIL" 2>/dev/null | true
+
+echo $QUERYMAYFAIL | $exec psql -U atmo_app tmp_sanitary_db || true
 
 # Create sanitary dump
-pg_dump tmp_sanitary_db > /tmp/{{ atmosphere_database_name }}-sanitized.sql;
+$exec pg_dump -U atmo_app tmp_sanitary_db > /tmp/{{ atmosphere_database_name }}-sanitized.sql;


### PR DESCRIPTION
## Description

Atmosphere Docker deployments no longer use Clank but the `sanitary-sql-access` role is still useful to create sanitary sql dumps and allow them to be gathered. 

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Updated CHANGELOG.md
- [ ] Documentation created/updated (include links)
- [ ] Reviewed and approved by at least one other contributor.
- [ ] New variables committed to secrets repos